### PR TITLE
Add unit tests for ProductController endpoints in Product Service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ build/
 
 ### VS Code ###
 .vscode/
+
+## Spring boot project configurations##
+.run

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,8 @@
     </scm>
     <properties>
         <java.version>21</java.version>
+        <mockito.version>5.16.1</mockito.version>
+        <byte-buddy-agent.version>1.15.11</byte-buddy-agent.version>
     </properties>
     <dependencies>
         <dependency>
@@ -80,6 +82,20 @@
             <artifactId>flyway-core</artifactId>
             <version>11.5.0</version>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/org.mockito/mockito-junit-jupiter -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>5.16.1</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- Add byte-buddy-agent explicitly -->
+        <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy-agent</artifactId>
+            <version>${byte-buddy-agent.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 
@@ -111,6 +127,19 @@
                             <artifactId>lombok</artifactId>
                         </exclude>
                     </excludes>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>
+                        -Xshare:off
+                        --add-opens java.base/java.lang=ALL-UNNAMED
+                        --add-opens java.base/java.util=ALL-UNNAMED
+                        --add-opens java.base/java.time=ALL-UNNAMED
+                        -javaagent:${settings.localRepository}/net/bytebuddy/byte-buddy-agent/${byte-buddy-agent.version}/byte-buddy-agent-${byte-buddy-agent.version}.jar
+                    </argLine>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/java/com/vibevault/productservice/controllers/ProductController.java
+++ b/src/main/java/com/vibevault/productservice/controllers/ProductController.java
@@ -9,6 +9,7 @@ import com.vibevault.productservice.services.ProductService;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/products")

--- a/src/main/java/com/vibevault/productservice/dtos/product/CreateProductRequestDto.java
+++ b/src/main/java/com/vibevault/productservice/dtos/product/CreateProductRequestDto.java
@@ -1,5 +1,6 @@
 package com.vibevault.productservice.dtos.product;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.vibevault.productservice.models.Category;
 import com.vibevault.productservice.models.Currency;
 import com.vibevault.productservice.models.Price;
@@ -9,6 +10,7 @@ import lombok.Data;
 import java.util.Date;
 
 @Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class CreateProductRequestDto {
     private String name;
     private String description;

--- a/src/main/java/com/vibevault/productservice/dtos/product/CreateProductResponseDto.java
+++ b/src/main/java/com/vibevault/productservice/dtos/product/CreateProductResponseDto.java
@@ -1,10 +1,12 @@
 package com.vibevault.productservice.dtos.product;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.vibevault.productservice.models.Price;
 import com.vibevault.productservice.models.Product;
 import lombok.Data;
 
 @Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class CreateProductResponseDto {
     private String id;
     private String name;

--- a/src/main/java/com/vibevault/productservice/dtos/product/GetProductResponseDto.java
+++ b/src/main/java/com/vibevault/productservice/dtos/product/GetProductResponseDto.java
@@ -1,5 +1,6 @@
 package com.vibevault.productservice.dtos.product;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.vibevault.productservice.models.Price;
 import com.vibevault.productservice.models.Product;
 import lombok.Data;
@@ -7,6 +8,7 @@ import lombok.Data;
 import java.util.List;
 
 @Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class GetProductResponseDto {
     private  String id;
     private String name;

--- a/src/main/java/com/vibevault/productservice/models/BaseModel.java
+++ b/src/main/java/com/vibevault/productservice/models/BaseModel.java
@@ -1,5 +1,6 @@
 package com.vibevault.productservice.models;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;

--- a/src/main/java/com/vibevault/productservice/models/Category.java
+++ b/src/main/java/com/vibevault/productservice/models/Category.java
@@ -1,5 +1,6 @@
 package com.vibevault.productservice.models;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -13,6 +14,7 @@ import java.util.List;
 @EqualsAndHashCode(callSuper = false)
 @ToString(callSuper = false)
 @Table(name = "categories")
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Category extends BaseModel{
     @Column(nullable = false, unique = true)
     private String name;

--- a/src/main/java/com/vibevault/productservice/models/Price.java
+++ b/src/main/java/com/vibevault/productservice/models/Price.java
@@ -1,5 +1,6 @@
 package com.vibevault.productservice.models;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 
@@ -17,6 +18,7 @@ import org.springframework.format.annotation.NumberFormat;
 @Embeddable
 @AllArgsConstructor
 @NoArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Price{
     @Column(nullable = false)
     @NumberFormat(pattern = "#,###,###,###.##", style = NumberFormat.Style.CURRENCY)

--- a/src/main/java/com/vibevault/productservice/models/Price.java
+++ b/src/main/java/com/vibevault/productservice/models/Price.java
@@ -5,7 +5,9 @@ import jakarta.persistence.Embeddable;
 
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.springframework.format.annotation.NumberFormat;
 
@@ -13,6 +15,8 @@ import org.springframework.format.annotation.NumberFormat;
 @Getter
 @Setter
 @Embeddable
+@AllArgsConstructor
+@NoArgsConstructor
 public class Price{
     @Column(nullable = false)
     @NumberFormat(pattern = "#,###,###,###.##", style = NumberFormat.Style.CURRENCY)

--- a/src/main/java/com/vibevault/productservice/models/Product.java
+++ b/src/main/java/com/vibevault/productservice/models/Product.java
@@ -1,4 +1,5 @@
 package com.vibevault.productservice.models;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.format.annotation.NumberFormat;
@@ -11,6 +12,7 @@ import org.springframework.format.annotation.NumberFormat;
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = false)
 @ToString(callSuper = false)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Product extends BaseModel{
     @Column(nullable = false, unique = true)
     @EqualsAndHashCode.Exclude

--- a/src/test/java/com/vibevault/productservice/config/TestConfig.java
+++ b/src/test/java/com/vibevault/productservice/config/TestConfig.java
@@ -1,0 +1,27 @@
+package com.vibevault.productservice.config;
+
+import com.vibevault.productservice.repositories.CategoryRepository;
+import com.vibevault.productservice.repositories.ProductRepository;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+@Configuration
+@EnableAutoConfiguration(exclude = {
+    DataSourceAutoConfiguration.class,
+    DataSourceTransactionManagerAutoConfiguration.class,
+    HibernateJpaAutoConfiguration.class,
+    FlywayAutoConfiguration.class
+})
+public class TestConfig {
+    
+    @MockitoBean
+    private ProductRepository productRepository;
+    
+    @MockitoBean
+    private CategoryRepository categoryRepository;
+}

--- a/src/test/java/com/vibevault/productservice/controllers/ProductControllerMVCTest.java
+++ b/src/test/java/com/vibevault/productservice/controllers/ProductControllerMVCTest.java
@@ -1,0 +1,151 @@
+package com.vibevault.productservice.controllers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.vibevault.productservice.dtos.product.CreateProductRequestDto;
+import com.vibevault.productservice.dtos.product.CreateProductResponseDto;
+import com.vibevault.productservice.dtos.product.GetProductResponseDto;
+import com.vibevault.productservice.models.Category;
+import com.vibevault.productservice.models.Currency;
+import com.vibevault.productservice.models.Price;
+import com.vibevault.productservice.models.Product;
+import com.vibevault.productservice.services.ProductService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultMatcher;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static net.bytebuddy.matcher.ElementMatchers.is;
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(ProductController.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public class ProductControllerMVCTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ProductService productService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private List<Product> products;
+    private List<Category> categories;
+    @BeforeEach
+    public void setup() {
+        // This method is called before each test
+        // You can initialize common objects or mock behaviors here if needed
+        initializeCategories();
+        initializeProducts();
+    }
+    private void initializeProducts() {
+        products = new ArrayList<>();
+
+        Product product = new Product();
+        product.setId(UUID.randomUUID());
+        product.setName("Test Product");
+        product.setDescription("Test Description");
+        product.setImageUrl("http://test.com/image.jpg");
+        product.setPrice(new Price(99.99, Currency.USD));
+        product.setCategory(categories.getFirst());
+        products.add(product);
+
+        Product product2 = new Product();
+        product2.setId(UUID.randomUUID());
+        product2.setName("Test Product 2");
+        product2.setDescription("Test Description 2");
+        product2.setImageUrl("http://test.com/image2.jpg");
+        product2.setPrice(new Price(199.99, Currency.EUR));
+        product2.setCategory(categories.get(1));
+        products.add(product2);
+
+        Product product3 = new Product();
+        product3.setId(UUID.randomUUID());
+        product3.setName("Test Product 3");
+        product3.setDescription("Test Description 3");
+        product3.setImageUrl("http://test.com/image3.jpg");
+        product3.setPrice(new Price(299.99, Currency.INR));
+        product3.setCategory(categories.getFirst());
+        products.add(product3);
+    }
+    private void initializeCategories() {
+        categories=new ArrayList<>();
+        Category category1 = new Category();
+        category1.setId(UUID.randomUUID());
+        category1.setName("Test Category");
+        category1.setDescription("Test Category Description");
+        categories.add(category1);
+
+        Category category2 = new Category();
+        category2.setId(UUID.randomUUID());
+        category2.setName("Test Category 2");
+        category2.setDescription("Test Category Description 2");
+        categories.add(category2);
+
+    }
+    @Test
+    public void test_getAllProducts_success() throws Exception {
+        // Mock the behavior of the productService to return a list of products
+        when(productService.getAllProducts()).thenReturn(products);
+
+        List<GetProductResponseDto> productResponseDtos = GetProductResponseDto.fromProducts(products);
+        mockMvc.perform(MockMvcRequestBuilders.get("/products"))
+                .andExpect(status().isOk())
+                .andExpect( content().string(objectMapper.writeValueAsString(productResponseDtos)));
+    }
+
+    @Test
+    public void test_createProduct_success() throws Exception {
+        // Mock the behavior of the productService to return a created product
+        Product toBeCreatedproduct = getToBeCreatedproduct();
+
+        Product createdProduct = products.get(0);
+        when(productService.createProduct(toBeCreatedproduct)).thenReturn(createdProduct);
+
+        CreateProductRequestDto requestDto = getCreateProductRequestDto(toBeCreatedproduct);
+
+        CreateProductResponseDto responseDto = CreateProductResponseDto.fromProduct(createdProduct);
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/products")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                .andExpect(status().isOk())
+                .andExpect(content().json(objectMapper.writeValueAsString(responseDto)));
+//                .andExpect(jsonPath("$.id").value(createdProduct.getId().toString()));
+    }
+
+    private CreateProductRequestDto getCreateProductRequestDto(Product toBeCreatedproduct) {
+        CreateProductRequestDto requestDto =new CreateProductRequestDto();
+        requestDto.setName(toBeCreatedproduct.getName());
+        requestDto.setDescription(toBeCreatedproduct.getDescription());
+        requestDto.setImageUrl(toBeCreatedproduct.getImageUrl());
+        requestDto.setPrice(toBeCreatedproduct.getPrice().getPrice());
+        requestDto.setCurrency(toBeCreatedproduct.getPrice().getCurrency());
+        requestDto.setCategoryName(toBeCreatedproduct.getCategory().getName());
+        return requestDto;
+    }
+
+    private Product getToBeCreatedproduct() {
+        Product toBeCreatedproduct =  new Product();
+        toBeCreatedproduct.setName(products.get(0).getName());
+        toBeCreatedproduct.setDescription(products.get(0).getDescription());
+        toBeCreatedproduct.setImageUrl(products.get(0).getImageUrl());
+        toBeCreatedproduct.setPrice(products.get(0).getPrice());
+        toBeCreatedproduct.setCategory(products.get(0).getCategory());
+        return toBeCreatedproduct;
+    }
+}

--- a/src/test/java/com/vibevault/productservice/controllers/ProductControllerTest.java
+++ b/src/test/java/com/vibevault/productservice/controllers/ProductControllerTest.java
@@ -23,6 +23,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
+import java.util.List;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -42,10 +43,13 @@ public class ProductControllerTest {
     @Captor
     private ArgumentCaptor<String> idCaptor;
 
+    private List<Product> products;
+    private List<Category> categories;
     @BeforeEach
     public void setup() {
         // This method is called before each test
         // You can initialize common objects or mock behaviors here if needed
+        initiaLizeCategories();
         initiaLizeProducts();
     }
     private void initiaLizeProducts() {
@@ -57,9 +61,17 @@ public class ProductControllerTest {
         product.setDescription("Test Description");
         product.setImageUrl("http://test.com/image.jpg");
         product.setPrice(new Price(99.99, Currency.USD));
+        product.setCategory(categories.get(0));
+
+        products = List.of(product);
+    }
+    private void initiaLizeCategories() {
         Category category = new Category();
+        category.setId(UUID.randomUUID());
         category.setName("Test Category");
-        product.setCategory(category);
+        category.setDescription("Test Category Description");
+
+        categories = List.of(category);
     }
 
     @Test
@@ -74,10 +86,7 @@ public class ProductControllerTest {
         requestDto.setCurrency(Currency.USD);
         requestDto.setCategoryName("Test Category");
 
-        Product product = requestDto.toProduct();
-        UUID id = UUID.randomUUID();
-        product.setId(id);
-
+        Product product = products.getFirst();
         when(productService.createProduct(any(Product.class))).thenReturn(product);
 
 
@@ -86,13 +95,13 @@ public class ProductControllerTest {
 
         // Assert
         assertNotNull(responseDto);
-        assertEquals(id.toString(), responseDto.getId());
-        assertEquals("Test Product", responseDto.getName());
-        assertEquals("Test Description", responseDto.getDescription());
-        assertEquals("http://test.com/image.jpg", responseDto.getImageUrl());
-        assertEquals("Test Category", responseDto.getCategoryName());
-        assertEquals(99.99, responseDto.getPrice().getPrice());
-        assertEquals(Currency.USD, responseDto.getPrice().getCurrency());
+        assertEquals(product.getId().toString(), responseDto.getId());
+        assertEquals(product.getName(), responseDto.getName());
+        assertEquals(product.getDescription(), responseDto.getDescription());
+        assertEquals(product.getImageUrl(), responseDto.getImageUrl());
+        assertEquals(product.getCategory().getName(), responseDto.getCategoryName());
+        assertEquals(product.getPrice().getPrice(), responseDto.getPrice().getPrice());
+        assertEquals(product.getPrice().getCurrency(), responseDto.getPrice().getCurrency());
 
         verify(productService, times(1)).createProduct(any(Product.class));
     }
@@ -101,34 +110,24 @@ public class ProductControllerTest {
     @Test
     public void test_get_product_success_When_Valid_Product_Id_Is_Passed_Returns_Product() throws ProductNotFoundException {
         // Arrange
-        String productId = UUID.randomUUID().toString();
-        Product product = new Product();
-        product.setId(UUID.fromString(productId));
-        product.setName("Test Product");
-        product.setDescription("Test Description");
-        product.setImageUrl("http://test.com/image.jpg");
-        product.setPrice(new Price(99.99, Currency.USD));
-        Category category = new Category();
-        category.setName("Test Category");
-        product.setCategory(category);
+        Product product = products.getFirst();
 
         when(productService.getProductById(anyString())).thenReturn(product);
 
         // Act
-        GetProductResponseDto responseDto = productController.getProductById(productId);
+        GetProductResponseDto responseDto = productController.getProductById(product.getId().toString());
 
         // Assert
         assertNotNull(responseDto);
-        assertEquals(productId, responseDto.getId());
-        assertEquals("Test Product", responseDto.getName());
-        assertEquals("Test Description", responseDto.getDescription());
-        assertEquals("http://test.com/image.jpg", responseDto.getImageUrl());
-        assertEquals("Test Category", responseDto.getCategoryName());
-        assertEquals(99.99, responseDto.getPrice().getPrice());
-        assertEquals(Currency.USD, responseDto.getPrice().getCurrency());
+        assertEquals(product.getName(), responseDto.getName());
+        assertEquals(product.getDescription(), responseDto.getDescription());
+        assertEquals(product.getImageUrl(), responseDto.getImageUrl());
+        assertEquals(product.getCategory().getName(), responseDto.getCategoryName());
+        assertEquals(product.getPrice().getPrice(), responseDto.getPrice().getPrice());
+        assertEquals(product.getPrice().getCurrency(), responseDto.getPrice().getCurrency());
 
         verify(productService, times(1)).getProductById(idCaptor.capture());
-        assertEquals(productId, idCaptor.getValue());
+        assertEquals(product.getId().toString(), idCaptor.getValue());
     }
 
     @Test

--- a/src/test/java/com/vibevault/productservice/controllers/ProductControllerTest.java
+++ b/src/test/java/com/vibevault/productservice/controllers/ProductControllerTest.java
@@ -1,5 +1,6 @@
 package com.vibevault.productservice.controllers;
 
+import com.vibevault.productservice.config.TestConfig;
 import com.vibevault.productservice.dtos.product.*;
 import com.vibevault.productservice.exceptions.products.ProductNotCreatedException;
 import com.vibevault.productservice.exceptions.products.ProductNotDeletedException;
@@ -29,7 +30,7 @@ import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-@SpringBootTest
+@SpringBootTest(classes = {ProductController.class, TestConfig.class})
 public class ProductControllerTest {
 
     @Autowired

--- a/src/test/java/com/vibevault/productservice/controllers/ProductControllerTest.java
+++ b/src/test/java/com/vibevault/productservice/controllers/ProductControllerTest.java
@@ -1,0 +1,150 @@
+package com.vibevault.productservice.controllers;
+
+import com.vibevault.productservice.dtos.product.*;
+import com.vibevault.productservice.exceptions.products.ProductNotCreatedException;
+import com.vibevault.productservice.exceptions.products.ProductNotDeletedException;
+import com.vibevault.productservice.exceptions.products.ProductNotFoundException;
+import com.vibevault.productservice.models.Category;
+import com.vibevault.productservice.models.Currency;
+import com.vibevault.productservice.models.Price;
+import com.vibevault.productservice.models.Product;
+import com.vibevault.productservice.services.ProductService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SpringBootTest
+public class ProductControllerTest {
+
+    @Autowired
+    private ProductController productController;
+
+    @MockitoBean
+    private ProductService productService;
+
+    @Captor
+    private ArgumentCaptor<String> idCaptor;
+
+    @BeforeEach
+    public void setup() {
+        // This method is called before each test
+        // You can initialize common objects or mock behaviors here if needed
+        initiaLizeProducts();
+    }
+    private void initiaLizeProducts() {
+        // Initialize any common objects or mock behaviors here
+        // For example, you can set up a mock product object
+        Product product = new Product();
+        product.setId(UUID.randomUUID());
+        product.setName("Test Product");
+        product.setDescription("Test Description");
+        product.setImageUrl("http://test.com/image.jpg");
+        product.setPrice(new Price(99.99, Currency.USD));
+        Category category = new Category();
+        category.setName("Test Category");
+        product.setCategory(category);
+    }
+
+    @Test
+    public void test_create_product_success_WhenValidProductObjectIsPassed_ReturnsSuccesfullyCreatedProduct() throws ProductNotCreatedException {
+        // Arrange
+
+        CreateProductRequestDto requestDto = new CreateProductRequestDto();
+        requestDto.setName("Test Product");
+        requestDto.setDescription("Test Description");
+        requestDto.setImageUrl("http://test.com/image.jpg");
+        requestDto.setPrice(99.99);
+        requestDto.setCurrency(Currency.USD);
+        requestDto.setCategoryName("Test Category");
+
+        Product product = requestDto.toProduct();
+        UUID id = UUID.randomUUID();
+        product.setId(id);
+
+        when(productService.createProduct(any(Product.class))).thenReturn(product);
+
+
+        // Act
+        CreateProductResponseDto responseDto = productController.createProduct(requestDto);
+
+        // Assert
+        assertNotNull(responseDto);
+        assertEquals(id.toString(), responseDto.getId());
+        assertEquals("Test Product", responseDto.getName());
+        assertEquals("Test Description", responseDto.getDescription());
+        assertEquals("http://test.com/image.jpg", responseDto.getImageUrl());
+        assertEquals("Test Category", responseDto.getCategoryName());
+        assertEquals(99.99, responseDto.getPrice().getPrice());
+        assertEquals(Currency.USD, responseDto.getPrice().getCurrency());
+
+        verify(productService, times(1)).createProduct(any(Product.class));
+    }
+
+
+    @Test
+    public void test_get_product_success_When_Valid_Product_Id_Is_Passed_Returns_Product() throws ProductNotFoundException {
+        // Arrange
+        String productId = UUID.randomUUID().toString();
+        Product product = new Product();
+        product.setId(UUID.fromString(productId));
+        product.setName("Test Product");
+        product.setDescription("Test Description");
+        product.setImageUrl("http://test.com/image.jpg");
+        product.setPrice(new Price(99.99, Currency.USD));
+        Category category = new Category();
+        category.setName("Test Category");
+        product.setCategory(category);
+
+        when(productService.getProductById(anyString())).thenReturn(product);
+
+        // Act
+        GetProductResponseDto responseDto = productController.getProductById(productId);
+
+        // Assert
+        assertNotNull(responseDto);
+        assertEquals(productId, responseDto.getId());
+        assertEquals("Test Product", responseDto.getName());
+        assertEquals("Test Description", responseDto.getDescription());
+        assertEquals("http://test.com/image.jpg", responseDto.getImageUrl());
+        assertEquals("Test Category", responseDto.getCategoryName());
+        assertEquals(99.99, responseDto.getPrice().getPrice());
+        assertEquals(Currency.USD, responseDto.getPrice().getCurrency());
+
+        verify(productService, times(1)).getProductById(idCaptor.capture());
+        assertEquals(productId, idCaptor.getValue());
+    }
+
+    @Test
+    public void test_get_product_throws_ProductNotFoundException_When_Invalid_Product_Id_Is_Passed() throws ProductNotFoundException {
+        // Arrange
+        String invalidProductId = "invalid-id";
+
+        when(productService.getProductById(anyString()))
+                .thenThrow(new ProductNotFoundException("Product not found"));
+
+        // Act & Assert
+        ProductNotFoundException exception=assertThrows(ProductNotFoundException.class, () -> {
+            productController.getProductById(invalidProductId);
+        });
+        assertEquals("Product not found", exception.getMessage());
+
+        verify(productService, times(1)).getProductById(idCaptor.capture());
+        assertEquals(invalidProductId, idCaptor.getValue());
+    }
+}


### PR DESCRIPTION
This pull request adds comprehensive unit tests for the ProductController class to improve test coverage and ensure API endpoint functionality.

Changes:

- Implemented unit tests for GET /products/{id} endpoint
- Added tests for POST /products endpoint with successful creation scenarios
- Created test fixtures for products and categories for reuse across tests
- Added error handling tests for non-existent product scenarios
- Configured test environment with MockitoExtension and proper test naming with DisplayNameGeneration

These tests validate JSON response structure, status codes, and business logic for the product API endpoints, ensuring the controller behaves as expected when interacting with the service layer.