### PR TITLE
Add Helm chart for productservice

### DIFF
--- a/helm/productservice/Chart.yaml
+++ b/helm/productservice/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: productservice
+description: Helm chart for VibeVault Product Service
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/helm/productservice/templates/NOTES.txt
+++ b/helm/productservice/templates/NOTES.txt
@@ -1,0 +1,20 @@
+Thank you for installing {{ .Chart.Name }}.
+
+Your release is named: {{ .Release.Name }}
+Namespace: {{ .Release.Namespace }}
+
+To check the status of your deployment:
+
+  kubectl get deployments -n {{ .Release.Namespace }}
+
+To access the productservice:
+
+  kubectl port-forward svc/{{ include "productservice.fullname" . }} {{ .Values.containerPort }}:{{ .Values.service.port }} -n {{ .Release.Namespace }}
+
+{{- if .Values.mysql.enabled }}
+
+MySQL is enabled and deployed as part of this release.
+To check MySQL status:
+
+  kubectl get pods -l app={{ include "productservice.fullname" . }}-mysql -n {{ .Release.Namespace }}
+{{- end }}

--- a/helm/productservice/templates/_helpers.tpl
+++ b/helm/productservice/templates/_helpers.tpl
@@ -1,0 +1,40 @@
+{{/*
+Chart name.
+*/}}
+{{- define "productservice.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Fullname.
+*/}}
+{{- define "productservice.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Common labels.
+*/}}
+{{- define "productservice.labels" -}}
+app: {{ include "productservice.name" . }}
+version: v1
+part-of: vibevault
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "productservice.selectorLabels" -}}
+app: {{ include "productservice.name" . }}
+{{- end }}

--- a/helm/productservice/templates/configmap.yaml
+++ b/helm/productservice/templates/configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "productservice.fullname" . }}-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "productservice.labels" . | nindent 4 }}
+data:
+  PORT: "{{ .Values.containerPort }}"
+  DB_URL: {{ .Values.config.dbUrl | default (printf "jdbc:mysql://%s-mysql:3306/productservice?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC" (include "productservice.fullname" .)) | quote }}
+  ISSUER_URI: {{ .Values.config.issuerUri | quote }}
+  SPRING_PROFILES_ACTIVE: {{ .Values.config.springProfilesActive | quote }}

--- a/helm/productservice/templates/deployment.yaml
+++ b/helm/productservice/templates/deployment.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "productservice.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "productservice.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "productservice.selectorLabels" . | nindent 6 }}
+  strategy:
+    type: {{ .Values.strategy.type }}
+    {{- if eq .Values.strategy.type "RollingUpdate" }}
+    rollingUpdate:
+      maxUnavailable: {{ .Values.strategy.rollingUpdate.maxUnavailable }}
+      maxSurge: {{ .Values.strategy.rollingUpdate.maxSurge }}
+    {{- end }}
+  template:
+    metadata:
+      labels:
+        {{- include "productservice.labels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: {{ include "productservice.name" . }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.containerPort }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "productservice.fullname" . }}-config
+            - secretRef:
+                name: {{ include "productservice.fullname" . }}-secret
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: {{ .Values.containerPort }}
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: {{ .Values.containerPort }}
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3

--- a/helm/productservice/templates/mysql-deployment.yaml
+++ b/helm/productservice/templates/mysql-deployment.yaml
@@ -1,0 +1,77 @@
+{{- if .Values.mysql.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "productservice.fullname" . }}-mysql
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ include "productservice.fullname" . }}-mysql
+    part-of: vibevault
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ include "productservice.fullname" . }}-mysql
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: {{ include "productservice.fullname" . }}-mysql
+        part-of: vibevault
+    spec:
+      containers:
+        - name: mysql
+          image: {{ .Values.mysql.image }}
+          ports:
+            - containerPort: 3306
+          env:
+            - name: MYSQL_DATABASE
+              value: productservice
+            - name: MYSQL_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "productservice.fullname" . }}-secret
+                  key: DB_USERNAME
+            - name: MYSQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "productservice.fullname" . }}-secret
+                  key: DB_PASSWORD
+            - name: MYSQL_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "productservice.fullname" . }}-secret
+                  key: DB_PASSWORD
+          resources:
+            {{- toYaml .Values.mysql.resources | nindent 12 }}
+          volumeMounts:
+            - name: mysql-storage
+              mountPath: /var/lib/mysql
+          readinessProbe:
+            exec:
+              command:
+                - mysqladmin
+                - ping
+                - -h
+                - "127.0.0.1"
+                - --protocol=TCP
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            exec:
+              command:
+                - mysqladmin
+                - ping
+                - -h
+                - "127.0.0.1"
+                - --protocol=TCP
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
+      volumes:
+        - name: mysql-storage
+          persistentVolumeClaim:
+            claimName: {{ include "productservice.fullname" . }}-mysql-pvc
+{{- end }}

--- a/helm/productservice/templates/mysql-pvc.yaml
+++ b/helm/productservice/templates/mysql-pvc.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.mysql.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "productservice.fullname" . }}-mysql-pvc
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ include "productservice.fullname" . }}-mysql
+    part-of: vibevault
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.mysql.storage }}
+{{- end }}

--- a/helm/productservice/templates/mysql-service.yaml
+++ b/helm/productservice/templates/mysql-service.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.mysql.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "productservice.fullname" . }}-mysql
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ include "productservice.fullname" . }}-mysql
+    part-of: vibevault
+spec:
+  type: ClusterIP
+  selector:
+    app: {{ include "productservice.fullname" . }}-mysql
+  ports:
+    - port: 3306
+      targetPort: 3306
+      protocol: TCP
+{{- end }}

--- a/helm/productservice/templates/secret.yaml
+++ b/helm/productservice/templates/secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "productservice.fullname" . }}-secret
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "productservice.labels" . | nindent 4 }}
+type: Opaque
+data:
+  DB_USERNAME: {{ .Values.secrets.dbUsername | b64enc | quote }}
+  DB_PASSWORD: {{ .Values.secrets.dbPassword | b64enc | quote }}

--- a/helm/productservice/templates/service.yaml
+++ b/helm/productservice/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "productservice.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "productservice.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    {{- include "productservice.selectorLabels" . | nindent 4 }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.containerPort }}
+      protocol: TCP

--- a/helm/productservice/values.yaml
+++ b/helm/productservice/values.yaml
@@ -1,0 +1,49 @@
+replicaCount: 2
+
+image:
+  repository: productservice
+  tag: latest
+  pullPolicy: IfNotPresent
+
+containerPort: 8080
+
+service:
+  type: ClusterIP
+  port: 80
+
+resources:
+  requests:
+    cpu: 250m
+    memory: 512Mi
+  limits:
+    cpu: 500m
+    memory: 768Mi
+
+strategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxUnavailable: 0
+    maxSurge: 1
+
+config:
+  # Leave empty to auto-generate from mysql service name.
+  # Override for external DB scenarios.
+  # dbUrl: ""
+  issuerUri: "http://userservice:8081"
+  springProfilesActive: "default"
+
+secrets:
+  dbUsername: productuser
+  dbPassword: productpass
+
+mysql:
+  enabled: true
+  image: mysql:8.0
+  storage: 1Gi
+  resources:
+    requests:
+      cpu: 250m
+      memory: 512Mi
+    limits:
+      cpu: 500m
+      memory: 768Mi


### PR DESCRIPTION
## Summary

This PR adds a Helm chart for the productservice, converting the existing raw Kubernetes manifests in `k8s/` into a proper parameterized chart under `helm/productservice/`.

The chart templatizes all the key configuration (image, replicas, resources, DB connection, secrets) so deployments can be customized per environment without editing manifests directly. MySQL is included as a conditional sub deployment that can be toggled off when using an external database.

## What's included

- `Chart.yaml` with apiVersion v2, appVersion 1.0.0
- `values.yaml` with sensible defaults matching the current raw manifests
- Templatized deployment, service, configmap, and secret for the productservice
- Conditional MySQL deployment, service, and PVC (controlled via `mysql.enabled`)
- Helper templates for consistent naming and labeling across resources
- `NOTES.txt` with post install instructions
- DB_URL auto generates from the release name so it stays correct regardless of what you name the release
- Strategy block is guarded so it only renders `rollingUpdate` when the strategy type is actually `RollingUpdate`

## Testing

- `helm lint helm/productservice/` passes clean
- `helm template` renders output equivalent to the existing `k8s/` manifests with default values
- No existing files were modified, everything is new under `helm/`

Closes #39