### PR TITLE
Add CI/CD pipeline and DB init Helm hook

### DIFF
--- a/helm/productservice/templates/db-init-hook.yaml
+++ b/helm/productservice/templates/db-init-hook.yaml
@@ -1,0 +1,73 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "productservice.fullname" . }}-db-init
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "productservice.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  ttlSecondsAfterFinished: 120
+  template:
+    metadata:
+      labels:
+        {{- include "productservice.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: db-init
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: db-init
+          image: mysql:8.0
+          securityContext:
+            runAsUser: 999
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          command:
+            - sh
+            - -c
+            - |
+              export MYSQL_PWD="$MASTER_PASSWORD"
+              printf 'CREATE DATABASE IF NOT EXISTS productservice;\nCREATE USER IF NOT EXISTS '\''productservice_user'\''@'\''%%'\'' IDENTIFIED BY '\''%s'\'';\nALTER USER '\''productservice_user'\''@'\''%%'\'' IDENTIFIED BY '\''%s'\'';\nGRANT SELECT, INSERT, UPDATE, DELETE, CREATE, ALTER, INDEX, DROP, REFERENCES ON productservice.* TO '\''productservice_user'\''@'\''%%'\'';\nFLUSH PRIVILEGES;\n' \
+                "$SERVICE_DB_PASSWORD" \
+                "$SERVICE_DB_PASSWORD" \
+              | mysql -h "$RDS_HOST" -P "$RDS_PORT" -u "$MASTER_USERNAME"
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+          env:
+            - name: RDS_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: db-init-config
+                  key: RDS_HOST
+            - name: RDS_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: db-init-config
+                  key: RDS_PORT
+            - name: MASTER_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: db-init-master-secret
+                  key: username
+            - name: MASTER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: db-init-master-secret
+                  key: password
+            - name: SERVICE_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: db-init-service-secrets
+                  key: productservice_password
+      volumes:
+        - name: tmp
+          emptyDir: {}


### PR DESCRIPTION
## Summary
- Replace Maven CI with GitHub Actions CI/CD: build, push to ECR, deploy to EKS via Helm
- Deploy workflow is manual-only (`workflow_dispatch`)
- Add concurrency group, `--create-namespace`, and pass image repo between jobs
- Add Helm `pre-install,pre-upgrade` hook to ensure DB user exists before every deploy

Closes #44
Closes #46

## Test plan
- [ ] CI pipeline triggers on PR to main
- [ ] Deploy workflow runs successfully via manual trigger
- [ ] DB init hook creates/updates MySQL user before app starts
- [ ] Pods reach Running state without `Access denied` errors