### PR TITLE
Exclude Spring Security auto-config in seed profile

### DIFF
--- a/src/main/resources/application-seed.yaml
+++ b/src/main/resources/application-seed.yaml
@@ -1,6 +1,10 @@
 spring:
   main:
     web-application-type: none
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration
+      - org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration
   datasource:
     hikari:
       maximum-pool-size: 5


### PR DESCRIPTION
## Summary
- Excludes `SecurityAutoConfiguration` and `OAuth2ResourceServerAutoConfiguration` in the `seed` Spring profile
- Fixes seed job failure: Spring Security tried to create a `JwtDecoder` bean even with `web-application-type: none`, since Security beans still initialize without a web server

## Test plan
- [ ] Deploy via deploy pipeline (rebuilds Docker image)
- [ ] Re-run seed job — should complete without `JwtDecoder` error