### PR TITLE
Fix seed profile: exclude SecurityConfig and fix job wait logic

### DIFF
--- a/.github/workflows/seed.yaml
+++ b/.github/workflows/seed.yaml
@@ -52,13 +52,19 @@ jobs:
 
       - name: Wait for seed job to complete
         run: |
-          kubectl wait --for=condition=complete --for=condition=failed job/seed-products -n vibevault --timeout=600s
-          STATUS=$(kubectl get job seed-products -n vibevault -o jsonpath='{.status.conditions[?(@.type=="Complete")].status}')
-          if [ "$STATUS" != "True" ]; then
-            echo "Seed job failed!"
-            exit 1
-          fi
+          while true; do
+            COMPLETE=$(kubectl get job seed-products -n vibevault -o jsonpath='{.status.conditions[?(@.type=="Complete")].status}' 2>/dev/null)
+            FAILED=$(kubectl get job seed-products -n vibevault -o jsonpath='{.status.conditions[?(@.type=="Failed")].status}' 2>/dev/null)
+            if [ "$COMPLETE" = "True" ]; then
+              echo "Seed job completed successfully."
+              break
+            elif [ "$FAILED" = "True" ]; then
+              echo "Seed job failed!"
+              exit 1
+            fi
+            sleep 5
+          done
 
       - name: Print seed job logs
         if: always()
-        run: kubectl logs job/seed-products -n vibevault
+        run: kubectl logs job/seed-products -n vibevault --pod-running-timeout=10s 2>&1 || echo "Could not retrieve logs (pod may have been cleaned up)"

--- a/src/main/java/com/vibevault/productservice/security/SecurityConfig.java
+++ b/src/main/java/com/vibevault/productservice/security/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.vibevault.productservice.security;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -14,6 +15,7 @@ import org.springframework.security.web.SecurityFilterChain;
 @Configuration
 @EnableWebSecurity
 @EnableMethodSecurity
+@Profile("!seed")
 public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception{


### PR DESCRIPTION
## Summary
- Adds `@Profile("!seed")` to `SecurityConfig` — the `spring.autoconfigure.exclude` approach didn't work because `SecurityConfig` is a manually declared `@Configuration` bean, not auto-config
- Replaces broken `kubectl wait --for=condition=complete --for=condition=failed` with a polling loop — multiple `--for` flags use AND logic (not OR), causing the wait step to hang forever
- Adds `--pod-running-timeout` fallback to the logs step

## Root cause
- **SecurityConfig**: `@EnableWebSecurity` triggers `JwtDecoder` bean creation even with `web-application-type: none`. Auto-config exclusion only skips Spring Boot's auto-config classes, not component-scanned `@Configuration` beans.
- **kubectl wait**: Multiple `--for` flags require ALL conditions to be true simultaneously. A job can never be both `Complete` and `Failed`.

## Test plan
- [ ] Deploy via deploy pipeline (rebuild image with `@Profile` fix)
- [ ] Run seed job — should start and complete without `JwtDecoder` error
- [ ] Pipeline wait step should exit promptly on success or failure