### PR TITLE
Add k6 benchmark scripts for MySQL baseline

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -1,0 +1,148 @@
+name: Benchmark
+
+on:
+  workflow_dispatch:
+    inputs:
+      test_script:
+        description: 'Benchmark script to run'
+        required: true
+        default: 'mysql-baseline.js'
+        type: choice
+        options:
+          - mysql-baseline.js
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  AWS_REGION: ap-south-1
+  EKS_CLUSTER_NAME: vibevault-dev
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  benchmark:
+    name: Run Benchmark
+    runs-on: ubuntu-latest
+    environment: dev
+    concurrency:
+      group: benchmark-productservice-dev
+      cancel-in-progress: false
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Configure kubectl
+        run: aws eks update-kubeconfig --name ${{ env.EKS_CLUSTER_NAME }} --region ${{ env.AWS_REGION }}
+
+      - name: Verify productservice is running
+        run: |
+          kubectl rollout status deployment/productservice -n vibevault --timeout=60s
+
+      - name: Delete previous benchmark resources
+        run: |
+          kubectl delete job benchmark-mysql-baseline -n vibevault --ignore-not-found
+          kubectl delete configmap k6-benchmark-script -n vibevault --ignore-not-found
+
+      - name: Create ConfigMap from benchmark script
+        run: |
+          kubectl create configmap k6-benchmark-script \
+            -n vibevault \
+            --from-file=${{ inputs.test_script }}=benchmarks/${{ inputs.test_script }}
+
+      - name: Apply benchmark job
+        run: |
+          # Extract only the Job manifest (skip the ConfigMap template — we created it above)
+          kubectl apply -f - <<'EOF'
+          apiVersion: batch/v1
+          kind: Job
+          metadata:
+            name: benchmark-mysql-baseline
+            namespace: vibevault
+            labels:
+              app: productservice
+              part-of: vibevault
+              purpose: benchmark
+          spec:
+            backoffLimit: 0
+            ttlSecondsAfterFinished: 600
+            template:
+              metadata:
+                labels:
+                  app: productservice
+                  purpose: benchmark
+              spec:
+                restartPolicy: Never
+                containers:
+                  - name: k6
+                    image: grafana/k6:latest
+                    command:
+                      - k6
+                      - run
+                      - --summary-trend-stats=min,avg,med,p(90),p(95),p(99),max
+                      - --env
+                      - BASE_URL=http://productservice:80
+                      - /scripts/${{ inputs.test_script }}
+                    volumeMounts:
+                      - name: k6-scripts
+                        mountPath: /scripts
+                        readOnly: true
+                    resources:
+                      requests:
+                        cpu: 500m
+                        memory: 256Mi
+                      limits:
+                        cpu: "1"
+                        memory: 512Mi
+                volumes:
+                  - name: k6-scripts
+                    configMap:
+                      name: k6-benchmark-script
+          EOF
+
+      - name: Wait for benchmark to complete
+        run: |
+          echo "Benchmark running (~15 minutes)..."
+          while true; do
+            COMPLETE=$(kubectl get job benchmark-mysql-baseline -n vibevault -o jsonpath='{.status.conditions[?(@.type=="Complete")].status}' 2>/dev/null)
+            FAILED=$(kubectl get job benchmark-mysql-baseline -n vibevault -o jsonpath='{.status.conditions[?(@.type=="Failed")].status}' 2>/dev/null)
+            if [ "$COMPLETE" = "True" ]; then
+              echo "Benchmark completed successfully."
+              break
+            elif [ "$FAILED" = "True" ]; then
+              echo "Benchmark job failed!"
+              exit 1
+            fi
+            # Print a progress dot every 30s
+            printf "."
+            sleep 30
+          done
+
+      - name: Capture benchmark results
+        if: always()
+        run: |
+          echo "==============================================="
+          echo "  BENCHMARK RESULTS: ${{ inputs.test_script }}"
+          echo "  Target: productservice (in-cluster)"
+          echo "  Dataset: 2M products, 50 categories"
+          echo "  Date: $(date -u +'%Y-%m-%d %H:%M UTC')"
+          echo "==============================================="
+          echo ""
+          kubectl logs job/benchmark-mysql-baseline -n vibevault --pod-running-timeout=10s 2>&1 | tee /tmp/benchmark-results.log
+          echo ""
+
+      - name: Upload results as artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results-${{ inputs.test_script }}-${{ github.run_number }}
+          path: /tmp/benchmark-results.log
+          retention-days: 90

--- a/benchmarks/.gitignore
+++ b/benchmarks/.gitignore
@@ -1,0 +1,1 @@
+results/

--- a/benchmarks/k8s/benchmark-job.yaml
+++ b/benchmarks/k8s/benchmark-job.yaml
@@ -1,0 +1,57 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: k6-benchmark-script
+  namespace: vibevault
+  labels:
+    app: productservice
+    part-of: vibevault
+    purpose: benchmark
+data:
+  mysql-baseline.js: |
+    SCRIPT_PLACEHOLDER
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: benchmark-mysql-baseline
+  namespace: vibevault
+  labels:
+    app: productservice
+    part-of: vibevault
+    purpose: benchmark
+spec:
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 600
+  template:
+    metadata:
+      labels:
+        app: productservice
+        purpose: benchmark
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: k6
+          image: grafana/k6:latest
+          command:
+            - k6
+            - run
+            - --summary-trend-stats=min,avg,med,p(90),p(95),p(99),max
+            - --env
+            - BASE_URL=http://productservice:80
+            - /scripts/mysql-baseline.js
+          volumeMounts:
+            - name: k6-scripts
+              mountPath: /scripts
+              readOnly: true
+          resources:
+            requests:
+              cpu: 500m
+              memory: 256Mi
+            limits:
+              cpu: "1"
+              memory: 512Mi
+      volumes:
+        - name: k6-scripts
+          configMap:
+            name: k6-benchmark-script

--- a/benchmarks/mysql-baseline.js
+++ b/benchmarks/mysql-baseline.js
@@ -1,0 +1,237 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Trend, Counter } from 'k6/metrics';
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:8080';
+
+// Custom metrics per scenario
+const fullTextLatency     = new Trend('full_text_search_duration', true);
+const filteredLatency     = new Trend('filtered_sorted_paginated_duration', true);
+const multiFieldLatency   = new Trend('multi_field_search_duration', true);
+const autocompleteLatency = new Trend('autocomplete_duration', true);
+const getByIdLatency      = new Trend('get_by_id_duration', true);
+const categoriesLatency   = new Trend('get_categories_duration', true);
+const errors              = new Counter('errors');
+
+// ---------------------------------------------------------------------------
+// Scenarios — ramp from 1 → 10 → 50 VUs
+// ---------------------------------------------------------------------------
+export const options = {
+  scenarios: {
+    full_text_search: {
+      executor: 'ramping-vus',
+      exec: 'fullTextSearch',
+      startVUs: 1,
+      stages: [
+        { duration: '15s', target: 1 },   // warm-up: 1 VU
+        { duration: '30s', target: 10 },   // ramp to 10
+        { duration: '30s', target: 10 },   // hold 10
+        { duration: '30s', target: 50 },   // ramp to 50
+        { duration: '30s', target: 50 },   // hold 50
+        { duration: '15s', target: 0 },    // ramp down
+      ],
+    },
+    filtered_sorted_paginated: {
+      executor: 'ramping-vus',
+      exec: 'filteredSortedPaginated',
+      startVUs: 1,
+      startTime: '2m30s',
+      stages: [
+        { duration: '15s', target: 1 },
+        { duration: '30s', target: 10 },
+        { duration: '30s', target: 10 },
+        { duration: '30s', target: 50 },
+        { duration: '30s', target: 50 },
+        { duration: '15s', target: 0 },
+      ],
+    },
+    multi_field_search: {
+      executor: 'ramping-vus',
+      exec: 'multiFieldSearch',
+      startVUs: 1,
+      startTime: '5m',
+      stages: [
+        { duration: '15s', target: 1 },
+        { duration: '30s', target: 10 },
+        { duration: '30s', target: 10 },
+        { duration: '30s', target: 50 },
+        { duration: '30s', target: 50 },
+        { duration: '15s', target: 0 },
+      ],
+    },
+    autocomplete: {
+      executor: 'ramping-vus',
+      exec: 'autocomplete',
+      startVUs: 1,
+      startTime: '7m30s',
+      stages: [
+        { duration: '15s', target: 1 },
+        { duration: '30s', target: 10 },
+        { duration: '30s', target: 10 },
+        { duration: '30s', target: 50 },
+        { duration: '30s', target: 50 },
+        { duration: '15s', target: 0 },
+      ],
+    },
+    get_by_id: {
+      executor: 'ramping-vus',
+      exec: 'getById',
+      startVUs: 1,
+      startTime: '10m',
+      stages: [
+        { duration: '15s', target: 1 },
+        { duration: '30s', target: 10 },
+        { duration: '30s', target: 10 },
+        { duration: '30s', target: 50 },
+        { duration: '30s', target: 50 },
+        { duration: '15s', target: 0 },
+      ],
+    },
+    get_categories: {
+      executor: 'ramping-vus',
+      exec: 'getCategories',
+      startVUs: 1,
+      startTime: '12m30s',
+      stages: [
+        { duration: '15s', target: 1 },
+        { duration: '30s', target: 10 },
+        { duration: '30s', target: 10 },
+        { duration: '30s', target: 50 },
+        { duration: '30s', target: 50 },
+        { duration: '15s', target: 0 },
+      ],
+    },
+  },
+  thresholds: {
+    http_req_failed: ['rate<0.01'],
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Search terms — rotated per VU iteration to avoid MySQL query cache
+// ---------------------------------------------------------------------------
+const SEARCH_QUERIES = [
+  'leather wallet', 'cotton shirt', 'bamboo bottle', 'silk scarf',
+  'titanium watch', 'ceramic mug', 'wooden chair', 'steel belt',
+  'glass vase', 'copper lamp', 'velvet pillow', 'canvas bag',
+  'marble table', 'carbon cable', 'wool blanket', 'denim jacket',
+  'suede boots', 'bronze ring', 'crystal earrings', 'linen towel',
+];
+
+const PREFIXES = [
+  'Pre', 'Cla', 'Mod', 'Vin', 'Ele', 'Rus', 'Sle', 'Bol',
+  'Ref', 'Art', 'Lux', 'Com', 'Dur', 'Lig', 'Org', 'Han',
+  'Sma', 'Ult', 'Pro', 'Ess', 'Del', 'Eli', 'Roy', 'Nat',
+];
+
+const CATEGORIES = [
+  "Men's Clothing", "Women's Clothing", "Footwear", "Jewelry",
+  "Home Decor", "Furniture", "Kitchen & Dining", "Electronics Accessories",
+  "Beauty & Personal Care", "Sports & Outdoors",
+];
+
+// Cache a product ID from the first successful search
+let cachedProductId = null;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function pick(arr) {
+  return arr[Math.floor(Math.random() * arr.length)];
+}
+
+function doCheck(res, name, metricTrend) {
+  const ok = check(res, {
+    [`${name} status 200`]: (r) => r.status === 200,
+  });
+  metricTrend.add(res.timings.duration);
+  if (!ok) errors.add(1);
+  return ok;
+}
+
+// ---------------------------------------------------------------------------
+// Scenario functions
+// ---------------------------------------------------------------------------
+
+// 1. Full-text search: WHERE name LIKE '%leather wallet%'
+export function fullTextSearch() {
+  const query = pick(SEARCH_QUERIES);
+  const page = Math.floor(Math.random() * 5);
+  const res = http.get(
+    `${BASE_URL}/search/products?query=${encodeURIComponent(query)}&size=20&page=${page}`
+  );
+  if (doCheck(res, 'full_text_search', fullTextLatency) && !cachedProductId) {
+    try {
+      const body = JSON.parse(res.body);
+      if (body.products && body.products.length > 0) {
+        cachedProductId = body.products[0].id;
+      }
+    } catch (_) {}
+  }
+  sleep(0.5);
+}
+
+// 2. Filtered + sorted + paginated: category + price range + sort by price
+export function filteredSortedPaginated() {
+  const category = pick(CATEGORIES);
+  const minPrice = Math.floor(Math.random() * 500) + 50;
+  const maxPrice = minPrice + Math.floor(Math.random() * 5000) + 500;
+  const page = Math.floor(Math.random() * 10);
+  const sortDir = Math.random() > 0.5 ? 'asc' : 'desc';
+  const res = http.get(
+    `${BASE_URL}/search/products?categoryName=${encodeURIComponent(category)}&minPrice=${minPrice}&maxPrice=${maxPrice}&sortBy=price&sortDir=${sortDir}&size=20&page=${page}`
+  );
+  doCheck(res, 'filtered_sorted_paginated', filteredLatency);
+  sleep(0.5);
+}
+
+// 3. Multi-field search: query + category filter
+export function multiFieldSearch() {
+  const query = pick(SEARCH_QUERIES).split(' ')[0];
+  const category = pick(CATEGORIES);
+  const res = http.get(
+    `${BASE_URL}/search/products?query=${encodeURIComponent(query)}&categoryName=${encodeURIComponent(category)}&size=20`
+  );
+  doCheck(res, 'multi_field_search', multiFieldLatency);
+  sleep(0.5);
+}
+
+// 4. Autocomplete: prefix search
+export function autocomplete() {
+  const prefix = pick(PREFIXES);
+  const res = http.get(
+    `${BASE_URL}/search/products/suggest?prefix=${encodeURIComponent(prefix)}&limit=10`
+  );
+  doCheck(res, 'autocomplete', autocompleteLatency);
+  sleep(0.3);
+}
+
+// 5. Get product by ID
+export function getById() {
+  if (!cachedProductId) {
+    const searchRes = http.get(`${BASE_URL}/search/products?size=1`);
+    try {
+      const body = JSON.parse(searchRes.body);
+      if (body.products && body.products.length > 0) {
+        cachedProductId = body.products[0].id;
+      }
+    } catch (_) {}
+    if (!cachedProductId) {
+      sleep(1);
+      return;
+    }
+  }
+  const res = http.get(`${BASE_URL}/products/${cachedProductId}`);
+  doCheck(res, 'get_by_id', getByIdLatency);
+  sleep(0.3);
+}
+
+// 6. Get all categories (with product counts)
+export function getCategories() {
+  const res = http.get(`${BASE_URL}/categories`);
+  doCheck(res, 'get_categories', categoriesLatency);
+  sleep(0.5);
+}

--- a/benchmarks/run-mysql-baseline.sh
+++ b/benchmarks/run-mysql-baseline.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+RESULTS_DIR="$SCRIPT_DIR/results"
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+
+mkdir -p "$RESULTS_DIR"
+
+# Default: port-forward to EKS productservice
+BASE_URL="${BASE_URL:-http://localhost:8080}"
+
+echo "============================================"
+echo "  MySQL Baseline Benchmark"
+echo "  Target: $BASE_URL"
+echo "  Dataset: 2M products, 50 categories"
+echo "============================================"
+echo ""
+echo "Scenarios (run sequentially, each ~2.5 min):"
+echo "  1. Full-text search   (LIKE '%query%')"
+echo "  2. Filtered + sorted + paginated"
+echo "  3. Multi-field search (query + category)"
+echo "  4. Autocomplete       (prefix LIKE 'Pre%')"
+echo "  5. Get by ID          (primary key lookup)"
+echo "  6. Get categories     (all 50 categories)"
+echo ""
+echo "Total estimated time: ~15 minutes"
+echo "Results will be saved to: $RESULTS_DIR/"
+echo ""
+
+# Run k6
+k6 run \
+  --env BASE_URL="$BASE_URL" \
+  --summary-trend-stats="min,avg,med,p(90),p(95),p(99),max" \
+  --out csv="$RESULTS_DIR/mysql_baseline_${TIMESTAMP}.csv" \
+  "$SCRIPT_DIR/mysql-baseline.js" \
+  2>&1 | tee "$RESULTS_DIR/mysql_baseline_${TIMESTAMP}.log"
+
+echo ""
+echo "============================================"
+echo "  Benchmark complete!"
+echo "  Log:  $RESULTS_DIR/mysql_baseline_${TIMESTAMP}.log"
+echo "  CSV:  $RESULTS_DIR/mysql_baseline_${TIMESTAMP}.csv"
+echo "============================================"


### PR DESCRIPTION
## Summary
- Adds k6 load testing script with 6 scenarios: full-text search, filtered+sorted+paginated, multi-field search, autocomplete, get-by-id, get-categories
- Each scenario ramps 1 → 10 → 50 concurrent virtual users against 2M products
- Runs as a K8s Job (`grafana/k6`) inside the cluster targeting `http://productservice:80` — pure application latency, no port-forward noise
- GitHub Actions `benchmark.yaml` workflow (`workflow_dispatch`) with script selector, prints results in log + uploads as artifact (90-day retention)
- Local run script (`run-mysql-baseline.sh`) also included for dev use

## Test plan
- [ ] Merge and run "Benchmark" workflow from GitHub Actions
- [ ] Verify k6 job runs inside the cluster and completes ~15 min
- [ ] Check results in Actions log — all 6 scenarios report p50/p90/p95/p99 latencies
- [ ] Download artifact and verify log file

Closes #52