### PR TITLE
Fix OOMKill: Change Category.products to lazy fetch

### DIFF
--- a/src/main/java/com/vibevault/productservice/models/Category.java
+++ b/src/main/java/com/vibevault/productservice/models/Category.java
@@ -28,7 +28,7 @@ public class Category extends BaseModel{
     @ToString.Exclude
     private List<Product> featuredProducts;
 
-    @OneToMany(mappedBy = "category", fetch = FetchType.EAGER)
+    @OneToMany(mappedBy = "category", fetch = FetchType.LAZY)
     @EqualsAndHashCode.Exclude
     @ToString.Exclude
     private List<Product> products;

--- a/src/main/java/com/vibevault/productservice/services/CategoryServiceDBImpl.java
+++ b/src/main/java/com/vibevault/productservice/services/CategoryServiceDBImpl.java
@@ -7,6 +7,7 @@ import com.vibevault.productservice.models.Category;
 import com.vibevault.productservice.models.Product;
 import com.vibevault.productservice.repositories.CategoryRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
@@ -58,6 +59,7 @@ public class CategoryServiceDBImpl implements CategoryService{
     }
 
     @Override
+    @Transactional(readOnly = true)
     public List<Product> getProductsList(List<String> categoryUuids) throws CategoryNotFoundException {
         List<UUID> uuids = categoryUuids.stream().map(UUID::fromString).toList();
         List<Category> categories = categoryRepository.findAllByIdIn(uuids);
@@ -70,6 +72,7 @@ public class CategoryServiceDBImpl implements CategoryService{
     }
 
     @Override
+    @Transactional(readOnly = true)
     public List<Product> getProductsByCategory(String category) throws CategoryNotFoundException {
         Optional<Category> categoryOptional = categoryRepository.findByName(category);
         if (categoryOptional.isPresent()) {


### PR DESCRIPTION
## Summary
- Changed `Category.products` from `FetchType.EAGER` to `FetchType.LAZY` to prevent cascading load of all products (~40K per category) when any product is fetched
- Added `@Transactional(readOnly = true)` to `getProductsList()` and `getProductsByCategory()` to support lazy loading with `open-in-view=false`

## Root Cause
k6 benchmark against 2M products caused OOMKill (Exit Code 137) even at 1 VU. A paginated search returning 20 products triggered eager loading of `Category → ALL products`, flooding JVM heap with hundreds of thousands of entities + `@Lob` descriptions, exceeding the 768Mi pod memory limit.

Closes #55

## Test plan
- [x] All 203 unit tests pass
- [ ] Deploy and re-run k6 MySQL baseline benchmark — pods should remain stable with 0 restarts
- [ ] Verify `/categories/products/{category}` endpoint still returns products correctly