### PR TITLE
Add MySQL baseline benchmark results for search

### DIFF
--- a/benchmark-results-mysql-baseline-light/benchmark-results.log
+++ b/benchmark-results-mysql-baseline-light/benchmark-results.log
@@ -1,0 +1,7550 @@
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+
+     execution: local
+        script: /scripts/mysql-baseline-light.js
+        output: -
+
+     scenarios: (100.00%) 6 scenarios, 16 max VUs, 15m30s max duration (incl. graceful stop):
+              * full_text_search: Up to 15 looping VUs for 2m30s over 6 stages (gracefulRampDown: 30s, exec: fullTextSearch, gracefulStop: 30s)
+              * filtered_sorted_paginated: Up to 15 looping VUs for 2m30s over 6 stages (gracefulRampDown: 30s, exec: filteredSortedPaginated, startTime: 2m30s, gracefulStop: 30s)
+              * multi_field_search: Up to 15 looping VUs for 2m30s over 6 stages (gracefulRampDown: 30s, exec: multiFieldSearch, startTime: 5m0s, gracefulStop: 30s)
+              * autocomplete: Up to 15 looping VUs for 2m30s over 6 stages (gracefulRampDown: 30s, exec: autocomplete, startTime: 7m30s, gracefulStop: 30s)
+              * get_by_id: Up to 15 looping VUs for 2m30s over 6 stages (gracefulRampDown: 30s, exec: getById, startTime: 10m0s, gracefulStop: 30s)
+              * get_categories: Up to 15 looping VUs for 2m30s over 6 stages (gracefulRampDown: 30s, exec: getCategories, startTime: 12m30s, gracefulStop: 30s)
+
+
+running (00m01.0s), 01/16 VUs, 0 complete and 0 interrupted iterations
+full_text_search            [   1% ] 01/15 VUs  0m01.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    2m29.0s
+multi_field_search        • [   0% ] waiting    4m59.0s
+autocomplete              • [   0% ] waiting    7m29.0s
+get_by_id                 • [   0% ] waiting    09m59.0s
+get_categories            • [   0% ] waiting    12m29.0s
+
+running (00m02.0s), 01/16 VUs, 0 complete and 0 interrupted iterations
+full_text_search            [   1% ] 01/15 VUs  0m02.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    2m28.0s
+multi_field_search        • [   0% ] waiting    4m58.0s
+autocomplete              • [   0% ] waiting    7m28.0s
+get_by_id                 • [   0% ] waiting    09m58.0s
+get_categories            • [   0% ] waiting    12m28.0s
+
+running (00m03.0s), 01/16 VUs, 0 complete and 0 interrupted iterations
+full_text_search            [   2% ] 01/15 VUs  0m03.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    2m27.0s
+multi_field_search        • [   0% ] waiting    4m57.0s
+autocomplete              • [   0% ] waiting    7m27.0s
+get_by_id                 • [   0% ] waiting    09m57.0s
+get_categories            • [   0% ] waiting    12m27.0s
+
+running (00m04.0s), 01/16 VUs, 0 complete and 0 interrupted iterations
+full_text_search            [   3% ] 01/15 VUs  0m04.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    2m26.0s
+multi_field_search        • [   0% ] waiting    4m56.0s
+autocomplete              • [   0% ] waiting    7m26.0s
+get_by_id                 • [   0% ] waiting    09m56.0s
+get_categories            • [   0% ] waiting    12m26.0s
+
+running (00m05.0s), 01/16 VUs, 0 complete and 0 interrupted iterations
+full_text_search            [   3% ] 01/15 VUs  0m05.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    2m25.0s
+multi_field_search        • [   0% ] waiting    4m55.0s
+autocomplete              • [   0% ] waiting    7m25.0s
+get_by_id                 • [   0% ] waiting    09m55.0s
+get_categories            • [   0% ] waiting    12m25.0s
+
+running (00m06.0s), 01/16 VUs, 0 complete and 0 interrupted iterations
+full_text_search            [   4% ] 01/15 VUs  0m06.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    2m24.0s
+multi_field_search        • [   0% ] waiting    4m54.0s
+autocomplete              • [   0% ] waiting    7m24.0s
+get_by_id                 • [   0% ] waiting    09m54.0s
+get_categories            • [   0% ] waiting    12m24.0s
+
+running (00m07.0s), 01/16 VUs, 0 complete and 0 interrupted iterations
+full_text_search            [   5% ] 01/15 VUs  0m07.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    2m23.0s
+multi_field_search        • [   0% ] waiting    4m53.0s
+autocomplete              • [   0% ] waiting    7m23.0s
+get_by_id                 • [   0% ] waiting    09m53.0s
+get_categories            • [   0% ] waiting    12m23.0s
+
+running (00m08.0s), 01/16 VUs, 0 complete and 0 interrupted iterations
+full_text_search            [   5% ] 01/15 VUs  0m08.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    2m22.0s
+multi_field_search        • [   0% ] waiting    4m52.0s
+autocomplete              • [   0% ] waiting    7m22.0s
+get_by_id                 • [   0% ] waiting    09m52.0s
+get_categories            • [   0% ] waiting    12m22.0s
+
+running (00m09.0s), 01/16 VUs, 0 complete and 0 interrupted iterations
+full_text_search            [   6% ] 01/15 VUs  0m09.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    2m21.0s
+multi_field_search        • [   0% ] waiting    4m51.0s
+autocomplete              • [   0% ] waiting    7m21.0s
+get_by_id                 • [   0% ] waiting    09m51.0s
+get_categories            • [   0% ] waiting    12m21.0s
+
+running (00m10.0s), 01/16 VUs, 0 complete and 0 interrupted iterations
+full_text_search            [   7% ] 01/15 VUs  0m10.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    2m20.0s
+multi_field_search        • [   0% ] waiting    4m50.0s
+autocomplete              • [   0% ] waiting    7m20.0s
+get_by_id                 • [   0% ] waiting    09m50.0s
+get_categories            • [   0% ] waiting    12m20.0s
+
+running (00m11.0s), 01/16 VUs, 0 complete and 0 interrupted iterations
+full_text_search            [   7% ] 01/15 VUs  0m11.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    2m19.0s
+multi_field_search        • [   0% ] waiting    4m49.0s
+autocomplete              • [   0% ] waiting    7m19.0s
+get_by_id                 • [   0% ] waiting    09m49.0s
+get_categories            • [   0% ] waiting    12m19.0s
+
+running (00m12.0s), 01/16 VUs, 0 complete and 0 interrupted iterations
+full_text_search            [   8% ] 01/15 VUs  0m12.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    2m18.0s
+multi_field_search        • [   0% ] waiting    4m48.0s
+autocomplete              • [   0% ] waiting    7m18.0s
+get_by_id                 • [   0% ] waiting    09m48.0s
+get_categories            • [   0% ] waiting    12m18.0s
+
+running (00m13.0s), 01/16 VUs, 0 complete and 0 interrupted iterations
+full_text_search            [   9% ] 01/15 VUs  0m13.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    2m17.0s
+multi_field_search        • [   0% ] waiting    4m47.0s
+autocomplete              • [   0% ] waiting    7m17.0s
+get_by_id                 • [   0% ] waiting    09m47.0s
+get_categories            • [   0% ] waiting    12m17.0s
+
+running (00m14.0s), 01/16 VUs, 0 complete and 0 interrupted iterations
+full_text_search            [   9% ] 01/15 VUs  0m14.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    2m16.0s
+multi_field_search        • [   0% ] waiting    4m46.0s
+autocomplete              • [   0% ] waiting    7m16.0s
+get_by_id                 • [   0% ] waiting    09m46.0s
+get_categories            • [   0% ] waiting    12m16.0s
+
+running (00m15.0s), 01/16 VUs, 0 complete and 0 interrupted iterations
+full_text_search            [  10% ] 01/15 VUs  0m15.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    2m15.0s
+multi_field_search        • [   0% ] waiting    4m45.0s
+autocomplete              • [   0% ] waiting    7m15.0s
+get_by_id                 • [   0% ] waiting    09m45.0s
+get_categories            • [   0% ] waiting    12m15.0s
+
+running (00m16.0s), 01/16 VUs, 0 complete and 0 interrupted iterations
+full_text_search            [  11% ] 01/15 VUs  0m16.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    2m14.0s
+multi_field_search        • [   0% ] waiting    4m44.0s
+autocomplete              • [   0% ] waiting    7m14.0s
+get_by_id                 • [   0% ] waiting    09m44.0s
+get_categories            • [   0% ] waiting    12m14.0s
+
+running (00m17.0s), 01/16 VUs, 0 complete and 0 interrupted iterations
+full_text_search            [  11% ] 01/15 VUs  0m17.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    2m13.0s
+multi_field_search        • [   0% ] waiting    4m43.0s
+autocomplete              • [   0% ] waiting    7m13.0s
+get_by_id                 • [   0% ] waiting    09m43.0s
+get_categories            • [   0% ] waiting    12m13.0s
+
+running (00m18.0s), 01/16 VUs, 0 complete and 0 interrupted iterations
+full_text_search            [  12% ] 01/15 VUs  0m18.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    2m12.0s
+multi_field_search        • [   0% ] waiting    4m42.0s
+autocomplete              • [   0% ] waiting    7m12.0s
+get_by_id                 • [   0% ] waiting    09m42.0s
+get_categories            • [   0% ] waiting    12m12.0s
+
+running (00m19.0s), 01/16 VUs, 0 complete and 0 interrupted iterations
+full_text_search            [  13% ] 01/15 VUs  0m19.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    2m11.0s
+multi_field_search        • [   0% ] waiting    4m41.0s
+autocomplete              • [   0% ] waiting    7m11.0s
+get_by_id                 • [   0% ] waiting    09m41.0s
+get_categories            • [   0% ] waiting    12m11.0s
+
+running (00m20.0s), 01/16 VUs, 0 complete and 0 interrupted iterations
+full_text_search            [  13% ] 01/15 VUs  0m20.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    2m10.0s
+multi_field_search        • [   0% ] waiting    4m40.0s
+autocomplete              • [   0% ] waiting    7m10.0s
+get_by_id                 • [   0% ] waiting    09m40.0s
+get_categories            • [   0% ] waiting    12m10.0s
+
+running (00m21.0s), 01/16 VUs, 0 complete and 0 interrupted iterations
+full_text_search            [  14% ] 01/15 VUs  0m21.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    2m09.0s
+multi_field_search        • [   0% ] waiting    4m39.0s
+autocomplete              • [   0% ] waiting    7m09.0s
+get_by_id                 • [   0% ] waiting    09m39.0s
+get_categories            • [   0% ] waiting    12m09.0s
+
+running (00m22.0s), 01/16 VUs, 0 complete and 0 interrupted iterations
+full_text_search            [  15% ] 01/15 VUs  0m22.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    2m08.0s
+multi_field_search        • [   0% ] waiting    4m38.0s
+autocomplete              • [   0% ] waiting    7m08.0s
+get_by_id                 • [   0% ] waiting    09m38.0s
+get_categories            • [   0% ] waiting    12m08.0s
+
+running (00m23.0s), 02/16 VUs, 0 complete and 0 interrupted iterations
+full_text_search            [  15% ] 02/15 VUs  0m23.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    2m07.0s
+multi_field_search        • [   0% ] waiting    4m37.0s
+autocomplete              • [   0% ] waiting    7m07.0s
+get_by_id                 • [   0% ] waiting    09m37.0s
+get_categories            • [   0% ] waiting    12m07.0s
+
+running (00m24.0s), 02/16 VUs, 0 complete and 0 interrupted iterations
+full_text_search            [  16% ] 02/15 VUs  0m24.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    2m06.0s
+multi_field_search        • [   0% ] waiting    4m36.0s
+autocomplete              • [   0% ] waiting    7m06.0s
+get_by_id                 • [   0% ] waiting    09m36.0s
+get_categories            • [   0% ] waiting    12m06.0s
+
+running (00m25.0s), 02/16 VUs, 0 complete and 0 interrupted iterations
+full_text_search            [  17% ] 02/15 VUs  0m25.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    2m05.0s
+multi_field_search        • [   0% ] waiting    4m35.0s
+autocomplete              • [   0% ] waiting    7m05.0s
+get_by_id                 • [   0% ] waiting    09m35.0s
+get_categories            • [   0% ] waiting    12m05.0s
+
+running (00m26.0s), 02/16 VUs, 0 complete and 0 interrupted iterations
+full_text_search            [  17% ] 02/15 VUs  0m26.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    2m04.0s
+multi_field_search        • [   0% ] waiting    4m34.0s
+autocomplete              • [   0% ] waiting    7m04.0s
+get_by_id                 • [   0% ] waiting    09m34.0s
+get_categories            • [   0% ] waiting    12m04.0s
+
+running (00m27.0s), 02/16 VUs, 0 complete and 0 interrupted iterations
+full_text_search            [  18% ] 02/15 VUs  0m27.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    2m03.0s
+multi_field_search        • [   0% ] waiting    4m33.0s
+autocomplete              • [   0% ] waiting    7m03.0s
+get_by_id                 • [   0% ] waiting    09m33.0s
+get_categories            • [   0% ] waiting    12m03.0s
+
+running (00m28.0s), 02/16 VUs, 0 complete and 0 interrupted iterations
+full_text_search            [  19% ] 02/15 VUs  0m28.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    2m02.0s
+multi_field_search        • [   0% ] waiting    4m32.0s
+autocomplete              • [   0% ] waiting    7m02.0s
+get_by_id                 • [   0% ] waiting    09m32.0s
+get_categories            • [   0% ] waiting    12m02.0s
+
+running (00m29.0s), 02/16 VUs, 0 complete and 0 interrupted iterations
+full_text_search            [  19% ] 02/15 VUs  0m29.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    2m01.0s
+multi_field_search        • [   0% ] waiting    4m31.0s
+autocomplete              • [   0% ] waiting    7m01.0s
+get_by_id                 • [   0% ] waiting    09m31.0s
+get_categories            • [   0% ] waiting    12m01.0s
+
+running (00m30.0s), 02/16 VUs, 0 complete and 0 interrupted iterations
+full_text_search            [  20% ] 02/15 VUs  0m30.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    2m00.0s
+multi_field_search        • [   0% ] waiting    4m30.0s
+autocomplete              • [   0% ] waiting    7m00.0s
+get_by_id                 • [   0% ] waiting    09m30.0s
+get_categories            • [   0% ] waiting    12m00.0s
+
+running (00m31.0s), 03/16 VUs, 0 complete and 0 interrupted iterations
+full_text_search            [  21% ] 03/15 VUs  0m31.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m59.0s
+multi_field_search        • [   0% ] waiting    4m29.0s
+autocomplete              • [   0% ] waiting    6m59.0s
+get_by_id                 • [   0% ] waiting    09m29.0s
+get_categories            • [   0% ] waiting    11m59.0s
+
+running (00m32.0s), 03/16 VUs, 0 complete and 0 interrupted iterations
+full_text_search            [  21% ] 03/15 VUs  0m32.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m58.0s
+multi_field_search        • [   0% ] waiting    4m28.0s
+autocomplete              • [   0% ] waiting    6m58.0s
+get_by_id                 • [   0% ] waiting    09m28.0s
+get_categories            • [   0% ] waiting    11m58.0s
+
+running (00m33.0s), 03/16 VUs, 0 complete and 0 interrupted iterations
+full_text_search            [  22% ] 03/15 VUs  0m33.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m57.0s
+multi_field_search        • [   0% ] waiting    4m27.0s
+autocomplete              • [   0% ] waiting    6m57.0s
+get_by_id                 • [   0% ] waiting    09m27.0s
+get_categories            • [   0% ] waiting    11m57.0s
+
+running (00m34.0s), 03/16 VUs, 0 complete and 0 interrupted iterations
+full_text_search            [  23% ] 03/15 VUs  0m34.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m56.0s
+multi_field_search        • [   0% ] waiting    4m26.0s
+autocomplete              • [   0% ] waiting    6m56.0s
+get_by_id                 • [   0% ] waiting    09m26.0s
+get_categories            • [   0% ] waiting    11m56.0s
+
+running (00m35.0s), 03/16 VUs, 0 complete and 0 interrupted iterations
+full_text_search            [  23% ] 03/15 VUs  0m35.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m55.0s
+multi_field_search        • [   0% ] waiting    4m25.0s
+autocomplete              • [   0% ] waiting    6m55.0s
+get_by_id                 • [   0% ] waiting    09m25.0s
+get_categories            • [   0% ] waiting    11m55.0s
+
+running (00m36.0s), 03/16 VUs, 0 complete and 0 interrupted iterations
+full_text_search            [  24% ] 03/15 VUs  0m36.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m54.0s
+multi_field_search        • [   0% ] waiting    4m24.0s
+autocomplete              • [   0% ] waiting    6m54.0s
+get_by_id                 • [   0% ] waiting    09m24.0s
+get_categories            • [   0% ] waiting    11m54.0s
+
+running (00m37.0s), 03/16 VUs, 0 complete and 0 interrupted iterations
+full_text_search            [  25% ] 03/15 VUs  0m37.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m53.0s
+multi_field_search        • [   0% ] waiting    4m23.0s
+autocomplete              • [   0% ] waiting    6m53.0s
+get_by_id                 • [   0% ] waiting    09m23.0s
+get_categories            • [   0% ] waiting    11m53.0s
+
+running (00m38.0s), 04/16 VUs, 0 complete and 0 interrupted iterations
+full_text_search            [  25% ] 04/15 VUs  0m38.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m52.0s
+multi_field_search        • [   0% ] waiting    4m22.0s
+autocomplete              • [   0% ] waiting    6m52.0s
+get_by_id                 • [   0% ] waiting    09m22.0s
+get_categories            • [   0% ] waiting    11m52.0s
+
+running (00m39.0s), 04/16 VUs, 0 complete and 0 interrupted iterations
+full_text_search            [  26% ] 04/15 VUs  0m39.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m51.0s
+multi_field_search        • [   0% ] waiting    4m21.0s
+autocomplete              • [   0% ] waiting    6m51.0s
+get_by_id                 • [   0% ] waiting    09m21.0s
+get_categories            • [   0% ] waiting    11m51.0s
+
+running (00m40.0s), 04/16 VUs, 0 complete and 0 interrupted iterations
+full_text_search            [  27% ] 04/15 VUs  0m40.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m50.0s
+multi_field_search        • [   0% ] waiting    4m20.0s
+autocomplete              • [   0% ] waiting    6m50.0s
+get_by_id                 • [   0% ] waiting    09m20.0s
+get_categories            • [   0% ] waiting    11m50.0s
+
+running (00m41.0s), 04/16 VUs, 0 complete and 0 interrupted iterations
+full_text_search            [  27% ] 04/15 VUs  0m41.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m49.0s
+multi_field_search        • [   0% ] waiting    4m19.0s
+autocomplete              • [   0% ] waiting    6m49.0s
+get_by_id                 • [   0% ] waiting    09m19.0s
+get_categories            • [   0% ] waiting    11m49.0s
+
+running (00m42.0s), 04/16 VUs, 0 complete and 0 interrupted iterations
+full_text_search            [  28% ] 04/15 VUs  0m42.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m48.0s
+multi_field_search        • [   0% ] waiting    4m18.0s
+autocomplete              • [   0% ] waiting    6m48.0s
+get_by_id                 • [   0% ] waiting    09m18.0s
+get_categories            • [   0% ] waiting    11m48.0s
+
+running (00m43.0s), 04/16 VUs, 0 complete and 0 interrupted iterations
+full_text_search            [  29% ] 04/15 VUs  0m43.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m47.0s
+multi_field_search        • [   0% ] waiting    4m17.0s
+autocomplete              • [   0% ] waiting    6m47.0s
+get_by_id                 • [   0% ] waiting    09m17.0s
+get_categories            • [   0% ] waiting    11m47.0s
+
+running (00m44.0s), 04/16 VUs, 0 complete and 0 interrupted iterations
+full_text_search            [  29% ] 04/15 VUs  0m44.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m46.0s
+multi_field_search        • [   0% ] waiting    4m16.0s
+autocomplete              • [   0% ] waiting    6m46.0s
+get_by_id                 • [   0% ] waiting    09m16.0s
+get_categories            • [   0% ] waiting    11m46.0s
+
+running (00m45.0s), 04/16 VUs, 0 complete and 0 interrupted iterations
+full_text_search            [  30% ] 04/15 VUs  0m45.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m45.0s
+multi_field_search        • [   0% ] waiting    4m15.0s
+autocomplete              • [   0% ] waiting    6m45.0s
+get_by_id                 • [   0% ] waiting    09m15.0s
+get_categories            • [   0% ] waiting    11m45.0s
+time="2026-03-12T14:21:00Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=velvet%20pillow&size=20&page=4\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (00m46.0s), 05/16 VUs, 0 complete and 0 interrupted iterations
+full_text_search            [  31% ] 05/15 VUs  0m46.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m44.0s
+multi_field_search        • [   0% ] waiting    4m14.0s
+autocomplete              • [   0% ] waiting    6m44.0s
+get_by_id                 • [   0% ] waiting    09m14.0s
+get_categories            • [   0% ] waiting    11m44.0s
+
+running (00m47.0s), 05/16 VUs, 1 complete and 0 interrupted iterations
+full_text_search            [  31% ] 05/15 VUs  0m47.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m43.0s
+multi_field_search        • [   0% ] waiting    4m13.0s
+autocomplete              • [   0% ] waiting    6m43.0s
+get_by_id                 • [   0% ] waiting    09m13.0s
+get_categories            • [   0% ] waiting    11m43.0s
+
+running (00m48.0s), 05/16 VUs, 1 complete and 0 interrupted iterations
+full_text_search            [  32% ] 05/15 VUs  0m48.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m42.0s
+multi_field_search        • [   0% ] waiting    4m12.0s
+autocomplete              • [   0% ] waiting    6m42.0s
+get_by_id                 • [   0% ] waiting    09m12.0s
+get_categories            • [   0% ] waiting    11m42.0s
+
+running (00m49.0s), 05/16 VUs, 1 complete and 0 interrupted iterations
+full_text_search            [  33% ] 05/15 VUs  0m49.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m41.0s
+multi_field_search        • [   0% ] waiting    4m11.0s
+autocomplete              • [   0% ] waiting    6m41.0s
+get_by_id                 • [   0% ] waiting    09m11.0s
+get_categories            • [   0% ] waiting    11m41.0s
+
+running (00m50.0s), 05/16 VUs, 1 complete and 0 interrupted iterations
+full_text_search            [  33% ] 05/15 VUs  0m50.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m40.0s
+multi_field_search        • [   0% ] waiting    4m10.0s
+autocomplete              • [   0% ] waiting    6m40.0s
+get_by_id                 • [   0% ] waiting    09m10.0s
+get_categories            • [   0% ] waiting    11m40.0s
+
+running (00m51.0s), 05/16 VUs, 1 complete and 0 interrupted iterations
+full_text_search            [  34% ] 05/15 VUs  0m51.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m39.0s
+multi_field_search        • [   0% ] waiting    4m09.0s
+autocomplete              • [   0% ] waiting    6m39.0s
+get_by_id                 • [   0% ] waiting    09m09.0s
+get_categories            • [   0% ] waiting    11m39.0s
+
+running (00m52.0s), 05/16 VUs, 1 complete and 0 interrupted iterations
+full_text_search            [  35% ] 05/15 VUs  0m52.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m38.0s
+multi_field_search        • [   0% ] waiting    4m08.0s
+autocomplete              • [   0% ] waiting    6m38.0s
+get_by_id                 • [   0% ] waiting    09m08.0s
+get_categories            • [   0% ] waiting    11m38.0s
+
+running (00m53.0s), 05/16 VUs, 1 complete and 0 interrupted iterations
+full_text_search            [  35% ] 05/15 VUs  0m53.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m37.0s
+multi_field_search        • [   0% ] waiting    4m07.0s
+autocomplete              • [   0% ] waiting    6m37.0s
+get_by_id                 • [   0% ] waiting    09m07.0s
+get_categories            • [   0% ] waiting    11m37.0s
+
+running (00m54.0s), 05/16 VUs, 1 complete and 0 interrupted iterations
+full_text_search            [  36% ] 05/15 VUs  0m54.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m36.0s
+multi_field_search        • [   0% ] waiting    4m06.0s
+autocomplete              • [   0% ] waiting    6m36.0s
+get_by_id                 • [   0% ] waiting    09m06.0s
+get_categories            • [   0% ] waiting    11m36.0s
+
+running (00m55.0s), 05/16 VUs, 1 complete and 0 interrupted iterations
+full_text_search            [  37% ] 05/15 VUs  0m55.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m35.0s
+multi_field_search        • [   0% ] waiting    4m05.0s
+autocomplete              • [   0% ] waiting    6m35.0s
+get_by_id                 • [   0% ] waiting    09m05.0s
+get_categories            • [   0% ] waiting    11m35.0s
+
+running (00m56.0s), 05/16 VUs, 1 complete and 0 interrupted iterations
+full_text_search            [  37% ] 05/15 VUs  0m56.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m34.0s
+multi_field_search        • [   0% ] waiting    4m04.0s
+autocomplete              • [   0% ] waiting    6m34.0s
+get_by_id                 • [   0% ] waiting    09m04.0s
+get_categories            • [   0% ] waiting    11m34.0s
+
+running (00m57.0s), 05/16 VUs, 1 complete and 0 interrupted iterations
+full_text_search            [  38% ] 05/15 VUs  0m57.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m33.0s
+multi_field_search        • [   0% ] waiting    4m03.0s
+autocomplete              • [   0% ] waiting    6m33.0s
+get_by_id                 • [   0% ] waiting    09m03.0s
+get_categories            • [   0% ] waiting    11m33.0s
+
+running (00m58.0s), 05/16 VUs, 1 complete and 0 interrupted iterations
+full_text_search            [  39% ] 05/15 VUs  0m58.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m32.0s
+multi_field_search        • [   0% ] waiting    4m02.0s
+autocomplete              • [   0% ] waiting    6m32.0s
+get_by_id                 • [   0% ] waiting    09m02.0s
+get_categories            • [   0% ] waiting    11m32.0s
+
+running (00m59.0s), 05/16 VUs, 1 complete and 0 interrupted iterations
+full_text_search            [  39% ] 05/15 VUs  0m59.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m31.0s
+multi_field_search        • [   0% ] waiting    4m01.0s
+autocomplete              • [   0% ] waiting    6m31.0s
+get_by_id                 • [   0% ] waiting    09m01.0s
+get_categories            • [   0% ] waiting    11m31.0s
+
+running (01m00.0s), 05/16 VUs, 1 complete and 0 interrupted iterations
+full_text_search            [  40% ] 05/15 VUs  1m00.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m30.0s
+multi_field_search        • [   0% ] waiting    4m00.0s
+autocomplete              • [   0% ] waiting    6m30.0s
+get_by_id                 • [   0% ] waiting    09m00.0s
+get_categories            • [   0% ] waiting    11m30.0s
+time="2026-03-12T14:21:15Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=wooden%20chair&size=20&page=0\": request timeout"
+
+running (01m01.0s), 05/16 VUs, 1 complete and 0 interrupted iterations
+full_text_search            [  41% ] 05/15 VUs  1m01.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m29.0s
+multi_field_search        • [   0% ] waiting    3m59.0s
+autocomplete              • [   0% ] waiting    6m29.0s
+get_by_id                 • [   0% ] waiting    08m59.0s
+get_categories            • [   0% ] waiting    11m29.0s
+
+running (01m02.0s), 05/16 VUs, 2 complete and 0 interrupted iterations
+full_text_search            [  41% ] 05/15 VUs  1m02.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m28.0s
+multi_field_search        • [   0% ] waiting    3m58.0s
+autocomplete              • [   0% ] waiting    6m28.0s
+get_by_id                 • [   0% ] waiting    08m58.0s
+get_categories            • [   0% ] waiting    11m28.0s
+
+running (01m03.0s), 05/16 VUs, 2 complete and 0 interrupted iterations
+full_text_search            [  42% ] 05/15 VUs  1m03.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m27.0s
+multi_field_search        • [   0% ] waiting    3m57.0s
+autocomplete              • [   0% ] waiting    6m27.0s
+get_by_id                 • [   0% ] waiting    08m57.0s
+get_categories            • [   0% ] waiting    11m27.0s
+
+running (01m04.0s), 05/16 VUs, 2 complete and 0 interrupted iterations
+full_text_search            [  43% ] 05/15 VUs  1m04.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m26.0s
+multi_field_search        • [   0% ] waiting    3m56.0s
+autocomplete              • [   0% ] waiting    6m26.0s
+get_by_id                 • [   0% ] waiting    08m56.0s
+get_categories            • [   0% ] waiting    11m26.0s
+
+running (01m05.0s), 05/16 VUs, 2 complete and 0 interrupted iterations
+full_text_search            [  43% ] 05/15 VUs  1m05.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m25.0s
+multi_field_search        • [   0% ] waiting    3m55.0s
+autocomplete              • [   0% ] waiting    6m25.0s
+get_by_id                 • [   0% ] waiting    08m55.0s
+get_categories            • [   0% ] waiting    11m25.0s
+
+running (01m06.0s), 05/16 VUs, 2 complete and 0 interrupted iterations
+full_text_search            [  44% ] 05/15 VUs  1m06.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m24.0s
+multi_field_search        • [   0% ] waiting    3m54.0s
+autocomplete              • [   0% ] waiting    6m24.0s
+get_by_id                 • [   0% ] waiting    08m54.0s
+get_categories            • [   0% ] waiting    11m24.0s
+
+running (01m07.0s), 05/16 VUs, 2 complete and 0 interrupted iterations
+full_text_search            [  45% ] 05/15 VUs  1m07.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m23.0s
+multi_field_search        • [   0% ] waiting    3m53.0s
+autocomplete              • [   0% ] waiting    6m23.0s
+get_by_id                 • [   0% ] waiting    08m53.0s
+get_categories            • [   0% ] waiting    11m23.0s
+
+running (01m08.0s), 05/16 VUs, 2 complete and 0 interrupted iterations
+full_text_search            [  45% ] 05/15 VUs  1m08.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m22.0s
+multi_field_search        • [   0% ] waiting    3m52.0s
+autocomplete              • [   0% ] waiting    6m22.0s
+get_by_id                 • [   0% ] waiting    08m52.0s
+get_categories            • [   0% ] waiting    11m22.0s
+
+running (01m09.0s), 05/16 VUs, 2 complete and 0 interrupted iterations
+full_text_search            [  46% ] 05/15 VUs  1m09.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m21.0s
+multi_field_search        • [   0% ] waiting    3m51.0s
+autocomplete              • [   0% ] waiting    6m21.0s
+get_by_id                 • [   0% ] waiting    08m51.0s
+get_categories            • [   0% ] waiting    11m21.0s
+
+running (01m10.0s), 05/16 VUs, 2 complete and 0 interrupted iterations
+full_text_search            [  47% ] 05/15 VUs  1m10.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m20.0s
+multi_field_search        • [   0% ] waiting    3m50.0s
+autocomplete              • [   0% ] waiting    6m20.0s
+get_by_id                 • [   0% ] waiting    08m50.0s
+get_categories            • [   0% ] waiting    11m20.0s
+
+running (01m11.0s), 05/16 VUs, 2 complete and 0 interrupted iterations
+full_text_search            [  47% ] 05/15 VUs  1m11.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m19.0s
+multi_field_search        • [   0% ] waiting    3m49.0s
+autocomplete              • [   0% ] waiting    6m19.0s
+get_by_id                 • [   0% ] waiting    08m49.0s
+get_categories            • [   0% ] waiting    11m19.0s
+
+running (01m12.0s), 05/16 VUs, 2 complete and 0 interrupted iterations
+full_text_search            [  48% ] 05/15 VUs  1m12.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m18.0s
+multi_field_search        • [   0% ] waiting    3m48.0s
+autocomplete              • [   0% ] waiting    6m18.0s
+get_by_id                 • [   0% ] waiting    08m48.0s
+get_categories            • [   0% ] waiting    11m18.0s
+
+running (01m13.0s), 05/16 VUs, 2 complete and 0 interrupted iterations
+full_text_search            [  49% ] 05/15 VUs  1m13.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m17.0s
+multi_field_search        • [   0% ] waiting    3m47.0s
+autocomplete              • [   0% ] waiting    6m17.0s
+get_by_id                 • [   0% ] waiting    08m47.0s
+get_categories            • [   0% ] waiting    11m17.0s
+
+running (01m14.0s), 05/16 VUs, 2 complete and 0 interrupted iterations
+full_text_search            [  49% ] 05/15 VUs  1m14.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m16.0s
+multi_field_search        • [   0% ] waiting    3m46.0s
+autocomplete              • [   0% ] waiting    6m16.0s
+get_by_id                 • [   0% ] waiting    08m46.0s
+get_categories            • [   0% ] waiting    11m16.0s
+
+running (01m15.0s), 05/16 VUs, 2 complete and 0 interrupted iterations
+full_text_search            [  50% ] 05/15 VUs  1m15.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m15.0s
+multi_field_search        • [   0% ] waiting    3m45.0s
+autocomplete              • [   0% ] waiting    6m15.0s
+get_by_id                 • [   0% ] waiting    08m45.0s
+get_categories            • [   0% ] waiting    11m15.0s
+
+running (01m16.0s), 05/16 VUs, 2 complete and 0 interrupted iterations
+full_text_search            [  51% ] 05/15 VUs  1m16.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m14.0s
+multi_field_search        • [   0% ] waiting    3m44.0s
+autocomplete              • [   0% ] waiting    6m14.0s
+get_by_id                 • [   0% ] waiting    08m44.0s
+get_categories            • [   0% ] waiting    11m14.0s
+
+running (01m17.0s), 05/16 VUs, 2 complete and 0 interrupted iterations
+full_text_search            [  51% ] 05/15 VUs  1m17.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m13.0s
+multi_field_search        • [   0% ] waiting    3m43.0s
+autocomplete              • [   0% ] waiting    6m13.0s
+get_by_id                 • [   0% ] waiting    08m43.0s
+get_categories            • [   0% ] waiting    11m13.0s
+
+running (01m18.0s), 05/16 VUs, 2 complete and 0 interrupted iterations
+full_text_search            [  52% ] 05/15 VUs  1m18.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m12.0s
+multi_field_search        • [   0% ] waiting    3m42.0s
+autocomplete              • [   0% ] waiting    6m12.0s
+get_by_id                 • [   0% ] waiting    08m42.0s
+get_categories            • [   0% ] waiting    11m12.0s
+time="2026-03-12T14:21:33Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=steel%20belt&size=20&page=1\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (01m19.0s), 06/16 VUs, 2 complete and 0 interrupted iterations
+full_text_search            [  53% ] 06/15 VUs  1m19.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m11.0s
+multi_field_search        • [   0% ] waiting    3m41.0s
+autocomplete              • [   0% ] waiting    6m11.0s
+get_by_id                 • [   0% ] waiting    08m41.0s
+get_categories            • [   0% ] waiting    11m11.0s
+
+running (01m20.0s), 06/16 VUs, 3 complete and 0 interrupted iterations
+full_text_search            [  53% ] 06/15 VUs  1m20.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m10.0s
+multi_field_search        • [   0% ] waiting    3m40.0s
+autocomplete              • [   0% ] waiting    6m10.0s
+get_by_id                 • [   0% ] waiting    08m40.0s
+get_categories            • [   0% ] waiting    11m10.0s
+
+running (01m21.0s), 06/16 VUs, 3 complete and 0 interrupted iterations
+full_text_search            [  54% ] 06/15 VUs  1m21.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m09.0s
+multi_field_search        • [   0% ] waiting    3m39.0s
+autocomplete              • [   0% ] waiting    6m09.0s
+get_by_id                 • [   0% ] waiting    08m39.0s
+get_categories            • [   0% ] waiting    11m09.0s
+
+running (01m22.0s), 07/16 VUs, 3 complete and 0 interrupted iterations
+full_text_search            [  55% ] 07/15 VUs  1m22.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m08.0s
+multi_field_search        • [   0% ] waiting    3m38.0s
+autocomplete              • [   0% ] waiting    6m08.0s
+get_by_id                 • [   0% ] waiting    08m38.0s
+get_categories            • [   0% ] waiting    11m08.0s
+time="2026-03-12T14:21:37Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=glass%20vase&size=20&page=4\": request timeout"
+
+running (01m23.0s), 07/16 VUs, 3 complete and 0 interrupted iterations
+full_text_search            [  55% ] 07/15 VUs  1m23.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m07.0s
+multi_field_search        • [   0% ] waiting    3m37.0s
+autocomplete              • [   0% ] waiting    6m07.0s
+get_by_id                 • [   0% ] waiting    08m37.0s
+get_categories            • [   0% ] waiting    11m07.0s
+
+running (01m24.0s), 07/16 VUs, 4 complete and 0 interrupted iterations
+full_text_search            [  56% ] 07/15 VUs  1m24.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m06.0s
+multi_field_search        • [   0% ] waiting    3m36.0s
+autocomplete              • [   0% ] waiting    6m06.0s
+get_by_id                 • [   0% ] waiting    08m36.0s
+get_categories            • [   0% ] waiting    11m06.0s
+
+running (01m25.0s), 08/16 VUs, 4 complete and 0 interrupted iterations
+full_text_search            [  57% ] 08/15 VUs  1m25.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m05.0s
+multi_field_search        • [   0% ] waiting    3m35.0s
+autocomplete              • [   0% ] waiting    6m05.0s
+get_by_id                 • [   0% ] waiting    08m35.0s
+get_categories            • [   0% ] waiting    11m05.0s
+
+running (01m26.0s), 08/16 VUs, 4 complete and 0 interrupted iterations
+full_text_search            [  57% ] 08/15 VUs  1m26.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m04.0s
+multi_field_search        • [   0% ] waiting    3m34.0s
+autocomplete              • [   0% ] waiting    6m04.0s
+get_by_id                 • [   0% ] waiting    08m34.0s
+get_categories            • [   0% ] waiting    11m04.0s
+
+running (01m27.0s), 08/16 VUs, 4 complete and 0 interrupted iterations
+full_text_search            [  58% ] 08/15 VUs  1m27.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m03.0s
+multi_field_search        • [   0% ] waiting    3m33.0s
+autocomplete              • [   0% ] waiting    6m03.0s
+get_by_id                 • [   0% ] waiting    08m33.0s
+get_categories            • [   0% ] waiting    11m03.0s
+
+running (01m28.0s), 09/16 VUs, 4 complete and 0 interrupted iterations
+full_text_search            [  59% ] 09/15 VUs  1m28.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m02.0s
+multi_field_search        • [   0% ] waiting    3m32.0s
+autocomplete              • [   0% ] waiting    6m02.0s
+get_by_id                 • [   0% ] waiting    08m32.0s
+get_categories            • [   0% ] waiting    11m02.0s
+
+running (01m29.0s), 09/16 VUs, 4 complete and 0 interrupted iterations
+full_text_search            [  59% ] 09/15 VUs  1m29.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m01.0s
+multi_field_search        • [   0% ] waiting    3m31.0s
+autocomplete              • [   0% ] waiting    6m01.0s
+get_by_id                 • [   0% ] waiting    08m31.0s
+get_categories            • [   0% ] waiting    11m01.0s
+
+running (01m30.0s), 09/16 VUs, 4 complete and 0 interrupted iterations
+full_text_search            [  60% ] 09/15 VUs  1m30.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m00.0s
+multi_field_search        • [   0% ] waiting    3m30.0s
+autocomplete              • [   0% ] waiting    6m00.0s
+get_by_id                 • [   0% ] waiting    08m30.0s
+get_categories            • [   0% ] waiting    11m00.0s
+time="2026-03-12T14:21:45Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=titanium%20watch&size=20&page=2\": request timeout"
+
+running (01m31.0s), 10/16 VUs, 4 complete and 0 interrupted iterations
+full_text_search            [  61% ] 10/15 VUs  1m31.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m59.0s
+multi_field_search        • [   0% ] waiting    3m29.0s
+autocomplete              • [   0% ] waiting    5m59.0s
+get_by_id                 • [   0% ] waiting    08m29.0s
+get_categories            • [   0% ] waiting    10m59.0s
+
+running (01m32.0s), 10/16 VUs, 5 complete and 0 interrupted iterations
+full_text_search            [  61% ] 10/15 VUs  1m32.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m58.0s
+multi_field_search        • [   0% ] waiting    3m28.0s
+autocomplete              • [   0% ] waiting    5m58.0s
+get_by_id                 • [   0% ] waiting    08m28.0s
+get_categories            • [   0% ] waiting    10m58.0s
+
+running (01m33.0s), 10/16 VUs, 5 complete and 0 interrupted iterations
+full_text_search            [  62% ] 10/15 VUs  1m33.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m57.0s
+multi_field_search        • [   0% ] waiting    3m27.0s
+autocomplete              • [   0% ] waiting    5m57.0s
+get_by_id                 • [   0% ] waiting    08m27.0s
+get_categories            • [   0% ] waiting    10m57.0s
+
+running (01m34.0s), 11/16 VUs, 5 complete and 0 interrupted iterations
+full_text_search            [  63% ] 11/15 VUs  1m34.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m56.0s
+multi_field_search        • [   0% ] waiting    3m26.0s
+autocomplete              • [   0% ] waiting    5m56.0s
+get_by_id                 • [   0% ] waiting    08m26.0s
+get_categories            • [   0% ] waiting    10m56.0s
+
+running (01m35.0s), 11/16 VUs, 5 complete and 0 interrupted iterations
+full_text_search            [  63% ] 11/15 VUs  1m35.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m55.0s
+multi_field_search        • [   0% ] waiting    3m25.0s
+autocomplete              • [   0% ] waiting    5m55.0s
+get_by_id                 • [   0% ] waiting    08m25.0s
+get_categories            • [   0% ] waiting    10m55.0s
+
+running (01m36.0s), 11/16 VUs, 5 complete and 0 interrupted iterations
+full_text_search            [  64% ] 11/15 VUs  1m36.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m54.0s
+multi_field_search        • [   0% ] waiting    3m24.0s
+autocomplete              • [   0% ] waiting    5m54.0s
+get_by_id                 • [   0% ] waiting    08m24.0s
+get_categories            • [   0% ] waiting    10m54.0s
+
+running (01m37.0s), 12/16 VUs, 5 complete and 0 interrupted iterations
+full_text_search            [  65% ] 12/15 VUs  1m37.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m53.0s
+multi_field_search        • [   0% ] waiting    3m23.0s
+autocomplete              • [   0% ] waiting    5m53.0s
+get_by_id                 • [   0% ] waiting    08m23.0s
+get_categories            • [   0% ] waiting    10m53.0s
+time="2026-03-12T14:21:52Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=wool%20blanket&size=20&page=0\": request timeout"
+
+running (01m38.0s), 12/16 VUs, 5 complete and 0 interrupted iterations
+full_text_search            [  65% ] 12/15 VUs  1m38.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m52.0s
+multi_field_search        • [   0% ] waiting    3m22.0s
+autocomplete              • [   0% ] waiting    5m52.0s
+get_by_id                 • [   0% ] waiting    08m22.0s
+get_categories            • [   0% ] waiting    10m52.0s
+
+running (01m39.0s), 12/16 VUs, 6 complete and 0 interrupted iterations
+full_text_search            [  66% ] 12/15 VUs  1m39.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m51.0s
+multi_field_search        • [   0% ] waiting    3m21.0s
+autocomplete              • [   0% ] waiting    5m51.0s
+get_by_id                 • [   0% ] waiting    08m21.0s
+get_categories            • [   0% ] waiting    10m51.0s
+
+running (01m40.0s), 13/16 VUs, 6 complete and 0 interrupted iterations
+full_text_search            [  67% ] 13/15 VUs  1m40.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m50.0s
+multi_field_search        • [   0% ] waiting    3m20.0s
+autocomplete              • [   0% ] waiting    5m50.0s
+get_by_id                 • [   0% ] waiting    08m20.0s
+get_categories            • [   0% ] waiting    10m50.0s
+
+running (01m41.0s), 13/16 VUs, 6 complete and 0 interrupted iterations
+full_text_search            [  67% ] 13/15 VUs  1m41.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m49.0s
+multi_field_search        • [   0% ] waiting    3m19.0s
+autocomplete              • [   0% ] waiting    5m49.0s
+get_by_id                 • [   0% ] waiting    08m19.0s
+get_categories            • [   0% ] waiting    10m49.0s
+
+running (01m42.0s), 13/16 VUs, 6 complete and 0 interrupted iterations
+full_text_search            [  68% ] 13/15 VUs  1m42.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m48.0s
+multi_field_search        • [   0% ] waiting    3m18.0s
+autocomplete              • [   0% ] waiting    5m48.0s
+get_by_id                 • [   0% ] waiting    08m18.0s
+get_categories            • [   0% ] waiting    10m48.0s
+
+running (01m43.0s), 14/16 VUs, 6 complete and 0 interrupted iterations
+full_text_search            [  69% ] 14/15 VUs  1m43.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m47.0s
+multi_field_search        • [   0% ] waiting    3m17.0s
+autocomplete              • [   0% ] waiting    5m47.0s
+get_by_id                 • [   0% ] waiting    08m17.0s
+get_categories            • [   0% ] waiting    10m47.0s
+
+running (01m44.0s), 14/16 VUs, 6 complete and 0 interrupted iterations
+full_text_search            [  69% ] 14/15 VUs  1m44.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m46.0s
+multi_field_search        • [   0% ] waiting    3m16.0s
+autocomplete              • [   0% ] waiting    5m46.0s
+get_by_id                 • [   0% ] waiting    08m16.0s
+get_categories            • [   0% ] waiting    10m46.0s
+
+running (01m45.0s), 14/16 VUs, 6 complete and 0 interrupted iterations
+full_text_search            [  70% ] 14/15 VUs  1m45.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m45.0s
+multi_field_search        • [   0% ] waiting    3m15.0s
+autocomplete              • [   0% ] waiting    5m45.0s
+get_by_id                 • [   0% ] waiting    08m15.0s
+get_categories            • [   0% ] waiting    10m45.0s
+time="2026-03-12T14:22:00Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=bronze%20ring&size=20&page=1\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (01m46.0s), 15/16 VUs, 6 complete and 0 interrupted iterations
+full_text_search            [  71% ] 15/15 VUs  1m46.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m44.0s
+multi_field_search        • [   0% ] waiting    3m14.0s
+autocomplete              • [   0% ] waiting    5m44.0s
+get_by_id                 • [   0% ] waiting    08m14.0s
+get_categories            • [   0% ] waiting    10m44.0s
+time="2026-03-12T14:22:01Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=leather%20wallet&size=20&page=1\": request timeout"
+
+running (01m47.0s), 15/16 VUs, 7 complete and 0 interrupted iterations
+full_text_search            [  71% ] 15/15 VUs  1m47.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m43.0s
+multi_field_search        • [   0% ] waiting    3m13.0s
+autocomplete              • [   0% ] waiting    5m43.0s
+get_by_id                 • [   0% ] waiting    08m13.0s
+get_categories            • [   0% ] waiting    10m43.0s
+
+running (01m48.0s), 15/16 VUs, 8 complete and 0 interrupted iterations
+full_text_search            [  72% ] 15/15 VUs  1m48.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m42.0s
+multi_field_search        • [   0% ] waiting    3m12.0s
+autocomplete              • [   0% ] waiting    5m42.0s
+get_by_id                 • [   0% ] waiting    08m12.0s
+get_categories            • [   0% ] waiting    10m42.0s
+
+running (01m49.0s), 15/16 VUs, 8 complete and 0 interrupted iterations
+full_text_search            [  73% ] 15/15 VUs  1m49.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m41.0s
+multi_field_search        • [   0% ] waiting    3m11.0s
+autocomplete              • [   0% ] waiting    5m41.0s
+get_by_id                 • [   0% ] waiting    08m11.0s
+get_categories            • [   0% ] waiting    10m41.0s
+
+running (01m50.0s), 15/16 VUs, 8 complete and 0 interrupted iterations
+full_text_search            [  73% ] 15/15 VUs  1m50.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m40.0s
+multi_field_search        • [   0% ] waiting    3m10.0s
+autocomplete              • [   0% ] waiting    5m40.0s
+get_by_id                 • [   0% ] waiting    08m10.0s
+get_categories            • [   0% ] waiting    10m40.0s
+
+running (01m51.0s), 15/16 VUs, 8 complete and 0 interrupted iterations
+full_text_search            [  74% ] 15/15 VUs  1m51.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m39.0s
+multi_field_search        • [   0% ] waiting    3m09.0s
+autocomplete              • [   0% ] waiting    5m39.0s
+get_by_id                 • [   0% ] waiting    08m09.0s
+get_categories            • [   0% ] waiting    10m39.0s
+
+running (01m52.0s), 15/16 VUs, 8 complete and 0 interrupted iterations
+full_text_search            [  75% ] 15/15 VUs  1m52.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m38.0s
+multi_field_search        • [   0% ] waiting    3m08.0s
+autocomplete              • [   0% ] waiting    5m38.0s
+get_by_id                 • [   0% ] waiting    08m08.0s
+get_categories            • [   0% ] waiting    10m38.0s
+
+running (01m53.0s), 15/16 VUs, 8 complete and 0 interrupted iterations
+full_text_search            [  75% ] 15/15 VUs  1m53.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m37.0s
+multi_field_search        • [   0% ] waiting    3m07.0s
+autocomplete              • [   0% ] waiting    5m37.0s
+get_by_id                 • [   0% ] waiting    08m07.0s
+get_categories            • [   0% ] waiting    10m37.0s
+
+running (01m54.0s), 15/16 VUs, 8 complete and 0 interrupted iterations
+full_text_search            [  76% ] 15/15 VUs  1m54.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m36.0s
+multi_field_search        • [   0% ] waiting    3m06.0s
+autocomplete              • [   0% ] waiting    5m36.0s
+get_by_id                 • [   0% ] waiting    08m06.0s
+get_categories            • [   0% ] waiting    10m36.0s
+
+running (01m55.0s), 15/16 VUs, 8 complete and 0 interrupted iterations
+full_text_search            [  77% ] 15/15 VUs  1m55.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m35.0s
+multi_field_search        • [   0% ] waiting    3m05.0s
+autocomplete              • [   0% ] waiting    5m35.0s
+get_by_id                 • [   0% ] waiting    08m05.0s
+get_categories            • [   0% ] waiting    10m35.0s
+
+running (01m56.0s), 15/16 VUs, 8 complete and 0 interrupted iterations
+full_text_search            [  77% ] 15/15 VUs  1m56.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m34.0s
+multi_field_search        • [   0% ] waiting    3m04.0s
+autocomplete              • [   0% ] waiting    5m34.0s
+get_by_id                 • [   0% ] waiting    08m04.0s
+get_categories            • [   0% ] waiting    10m34.0s
+
+running (01m57.0s), 15/16 VUs, 8 complete and 0 interrupted iterations
+full_text_search            [  78% ] 15/15 VUs  1m57.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m33.0s
+multi_field_search        • [   0% ] waiting    3m03.0s
+autocomplete              • [   0% ] waiting    5m33.0s
+get_by_id                 • [   0% ] waiting    08m03.0s
+get_categories            • [   0% ] waiting    10m33.0s
+
+running (01m58.0s), 15/16 VUs, 8 complete and 0 interrupted iterations
+full_text_search            [  79% ] 15/15 VUs  1m58.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m32.0s
+multi_field_search        • [   0% ] waiting    3m02.0s
+autocomplete              • [   0% ] waiting    5m32.0s
+get_by_id                 • [   0% ] waiting    08m02.0s
+get_categories            • [   0% ] waiting    10m32.0s
+
+running (01m59.0s), 15/16 VUs, 8 complete and 0 interrupted iterations
+full_text_search            [  79% ] 15/15 VUs  1m59.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m31.0s
+multi_field_search        • [   0% ] waiting    3m01.0s
+autocomplete              • [   0% ] waiting    5m31.0s
+get_by_id                 • [   0% ] waiting    08m01.0s
+get_categories            • [   0% ] waiting    10m31.0s
+
+running (02m00.0s), 15/16 VUs, 8 complete and 0 interrupted iterations
+full_text_search            [  80% ] 15/15 VUs  2m00.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m30.0s
+multi_field_search        • [   0% ] waiting    3m00.0s
+autocomplete              • [   0% ] waiting    5m30.0s
+get_by_id                 • [   0% ] waiting    08m00.0s
+get_categories            • [   0% ] waiting    10m30.0s
+
+running (02m01.0s), 15/16 VUs, 8 complete and 0 interrupted iterations
+full_text_search            [  81% ] 15/15 VUs  2m01.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m29.0s
+multi_field_search        • [   0% ] waiting    2m59.0s
+autocomplete              • [   0% ] waiting    5m29.0s
+get_by_id                 • [   0% ] waiting    07m59.0s
+get_categories            • [   0% ] waiting    10m29.0s
+time="2026-03-12T14:22:16Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=steel%20belt&size=20&page=4\": request timeout"
+
+running (02m02.0s), 15/16 VUs, 8 complete and 0 interrupted iterations
+full_text_search            [  81% ] 15/15 VUs  2m02.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m28.0s
+multi_field_search        • [   0% ] waiting    2m58.0s
+autocomplete              • [   0% ] waiting    5m28.0s
+get_by_id                 • [   0% ] waiting    07m58.0s
+get_categories            • [   0% ] waiting    10m28.0s
+
+running (02m03.0s), 15/16 VUs, 9 complete and 0 interrupted iterations
+full_text_search            [  82% ] 15/15 VUs  2m03.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m27.0s
+multi_field_search        • [   0% ] waiting    2m57.0s
+autocomplete              • [   0% ] waiting    5m27.0s
+get_by_id                 • [   0% ] waiting    07m57.0s
+get_categories            • [   0% ] waiting    10m27.0s
+
+running (02m04.0s), 15/16 VUs, 9 complete and 0 interrupted iterations
+full_text_search            [  83% ] 15/15 VUs  2m04.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m26.0s
+multi_field_search        • [   0% ] waiting    2m56.0s
+autocomplete              • [   0% ] waiting    5m26.0s
+get_by_id                 • [   0% ] waiting    07m56.0s
+get_categories            • [   0% ] waiting    10m26.0s
+
+running (02m05.0s), 15/16 VUs, 9 complete and 0 interrupted iterations
+full_text_search            [  83% ] 15/15 VUs  2m05.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m25.0s
+multi_field_search        • [   0% ] waiting    2m55.0s
+autocomplete              • [   0% ] waiting    5m25.0s
+get_by_id                 • [   0% ] waiting    07m55.0s
+get_categories            • [   0% ] waiting    10m25.0s
+
+running (02m06.0s), 15/16 VUs, 9 complete and 0 interrupted iterations
+full_text_search            [  84% ] 15/15 VUs  2m06.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m24.0s
+multi_field_search        • [   0% ] waiting    2m54.0s
+autocomplete              • [   0% ] waiting    5m24.0s
+get_by_id                 • [   0% ] waiting    07m54.0s
+get_categories            • [   0% ] waiting    10m24.0s
+
+running (02m07.0s), 15/16 VUs, 9 complete and 0 interrupted iterations
+full_text_search            [  85% ] 15/15 VUs  2m07.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m23.0s
+multi_field_search        • [   0% ] waiting    2m53.0s
+autocomplete              • [   0% ] waiting    5m23.0s
+get_by_id                 • [   0% ] waiting    07m53.0s
+get_categories            • [   0% ] waiting    10m23.0s
+
+running (02m08.0s), 15/16 VUs, 9 complete and 0 interrupted iterations
+full_text_search            [  85% ] 15/15 VUs  2m08.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m22.0s
+multi_field_search        • [   0% ] waiting    2m52.0s
+autocomplete              • [   0% ] waiting    5m22.0s
+get_by_id                 • [   0% ] waiting    07m52.0s
+get_categories            • [   0% ] waiting    10m22.0s
+
+running (02m09.0s), 15/16 VUs, 9 complete and 0 interrupted iterations
+full_text_search            [  86% ] 15/15 VUs  2m09.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m21.0s
+multi_field_search        • [   0% ] waiting    2m51.0s
+autocomplete              • [   0% ] waiting    5m21.0s
+get_by_id                 • [   0% ] waiting    07m51.0s
+get_categories            • [   0% ] waiting    10m21.0s
+
+running (02m10.0s), 15/16 VUs, 9 complete and 0 interrupted iterations
+full_text_search            [  87% ] 15/15 VUs  2m10.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m20.0s
+multi_field_search        • [   0% ] waiting    2m50.0s
+autocomplete              • [   0% ] waiting    5m20.0s
+get_by_id                 • [   0% ] waiting    07m50.0s
+get_categories            • [   0% ] waiting    10m20.0s
+
+running (02m11.0s), 15/16 VUs, 10 complete and 0 interrupted iterations
+full_text_search            [  87% ] 15/15 VUs  2m11.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m19.0s
+multi_field_search        • [   0% ] waiting    2m49.0s
+autocomplete              • [   0% ] waiting    5m19.0s
+get_by_id                 • [   0% ] waiting    07m49.0s
+get_categories            • [   0% ] waiting    10m19.0s
+
+running (02m12.0s), 15/16 VUs, 10 complete and 0 interrupted iterations
+full_text_search            [  88% ] 15/15 VUs  2m12.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m18.0s
+multi_field_search        • [   0% ] waiting    2m48.0s
+autocomplete              • [   0% ] waiting    5m18.0s
+get_by_id                 • [   0% ] waiting    07m48.0s
+get_categories            • [   0% ] waiting    10m18.0s
+
+running (02m13.0s), 15/16 VUs, 10 complete and 0 interrupted iterations
+full_text_search            [  89% ] 15/15 VUs  2m13.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m17.0s
+multi_field_search        • [   0% ] waiting    2m47.0s
+autocomplete              • [   0% ] waiting    5m17.0s
+get_by_id                 • [   0% ] waiting    07m47.0s
+get_categories            • [   0% ] waiting    10m17.0s
+
+running (02m14.0s), 15/16 VUs, 11 complete and 0 interrupted iterations
+full_text_search            [  89% ] 15/15 VUs  2m14.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m16.0s
+multi_field_search        • [   0% ] waiting    2m46.0s
+autocomplete              • [   0% ] waiting    5m16.0s
+get_by_id                 • [   0% ] waiting    07m46.0s
+get_categories            • [   0% ] waiting    10m16.0s
+
+running (02m15.0s), 15/16 VUs, 11 complete and 0 interrupted iterations
+full_text_search            [  90% ] 15/15 VUs  2m15.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m15.0s
+multi_field_search        • [   0% ] waiting    2m45.0s
+autocomplete              • [   0% ] waiting    5m15.0s
+get_by_id                 • [   0% ] waiting    07m45.0s
+get_categories            • [   0% ] waiting    10m15.0s
+
+running (02m16.0s), 15/16 VUs, 11 complete and 0 interrupted iterations
+full_text_search            [  91% ] 15/15 VUs  2m16.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m14.0s
+multi_field_search        • [   0% ] waiting    2m44.0s
+autocomplete              • [   0% ] waiting    5m14.0s
+get_by_id                 • [   0% ] waiting    07m44.0s
+get_categories            • [   0% ] waiting    10m14.0s
+
+running (02m17.0s), 15/16 VUs, 11 complete and 0 interrupted iterations
+full_text_search            [  91% ] 15/15 VUs  2m17.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m13.0s
+multi_field_search        • [   0% ] waiting    2m43.0s
+autocomplete              • [   0% ] waiting    5m13.0s
+get_by_id                 • [   0% ] waiting    07m43.0s
+get_categories            • [   0% ] waiting    10m13.0s
+
+running (02m18.0s), 15/16 VUs, 11 complete and 0 interrupted iterations
+full_text_search            [  92% ] 15/15 VUs  2m18.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m12.0s
+multi_field_search        • [   0% ] waiting    2m42.0s
+autocomplete              • [   0% ] waiting    5m12.0s
+get_by_id                 • [   0% ] waiting    07m42.0s
+get_categories            • [   0% ] waiting    10m12.0s
+
+running (02m19.0s), 15/16 VUs, 12 complete and 0 interrupted iterations
+full_text_search            [  93% ] 15/15 VUs  2m19.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m11.0s
+multi_field_search        • [   0% ] waiting    2m41.0s
+autocomplete              • [   0% ] waiting    5m11.0s
+get_by_id                 • [   0% ] waiting    07m41.0s
+get_categories            • [   0% ] waiting    10m11.0s
+time="2026-03-12T14:22:34Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=marble%20table&size=20&page=0\": request timeout"
+
+running (02m20.0s), 15/16 VUs, 12 complete and 0 interrupted iterations
+full_text_search            [  93% ] 15/15 VUs  2m20.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m10.0s
+multi_field_search        • [   0% ] waiting    2m40.0s
+autocomplete              • [   0% ] waiting    5m10.0s
+get_by_id                 • [   0% ] waiting    07m40.0s
+get_categories            • [   0% ] waiting    10m10.0s
+
+running (02m21.0s), 15/16 VUs, 13 complete and 0 interrupted iterations
+full_text_search            [  94% ] 15/15 VUs  2m21.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m09.0s
+multi_field_search        • [   0% ] waiting    2m39.0s
+autocomplete              • [   0% ] waiting    5m09.0s
+get_by_id                 • [   0% ] waiting    07m39.0s
+get_categories            • [   0% ] waiting    10m09.0s
+time="2026-03-12T14:22:36Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=bamboo%20bottle&size=20&page=3\": request timeout"
+
+running (02m22.0s), 15/16 VUs, 13 complete and 0 interrupted iterations
+full_text_search            [  95% ] 15/15 VUs  2m22.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m08.0s
+multi_field_search        • [   0% ] waiting    2m38.0s
+autocomplete              • [   0% ] waiting    5m08.0s
+get_by_id                 • [   0% ] waiting    07m38.0s
+get_categories            • [   0% ] waiting    10m08.0s
+
+running (02m23.0s), 15/16 VUs, 14 complete and 0 interrupted iterations
+full_text_search            [  95% ] 15/15 VUs  2m23.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m07.0s
+multi_field_search        • [   0% ] waiting    2m37.0s
+autocomplete              • [   0% ] waiting    5m07.0s
+get_by_id                 • [   0% ] waiting    07m37.0s
+get_categories            • [   0% ] waiting    10m07.0s
+time="2026-03-12T14:22:38Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=denim%20jacket&size=20&page=1\": request timeout"
+
+running (02m24.0s), 15/16 VUs, 14 complete and 0 interrupted iterations
+full_text_search            [  96% ] 15/15 VUs  2m24.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m06.0s
+multi_field_search        • [   0% ] waiting    2m36.0s
+autocomplete              • [   0% ] waiting    5m06.0s
+get_by_id                 • [   0% ] waiting    07m36.0s
+get_categories            • [   0% ] waiting    10m06.0s
+time="2026-03-12T14:22:39Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=silk%20scarf&size=20&page=0\": request timeout"
+time="2026-03-12T14:22:39Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=wool%20blanket&size=20&page=0\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (02m25.0s), 15/16 VUs, 15 complete and 0 interrupted iterations
+full_text_search            [  97% ] 15/15 VUs  2m25.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m05.0s
+multi_field_search        • [   0% ] waiting    2m35.0s
+autocomplete              • [   0% ] waiting    5m05.0s
+get_by_id                 • [   0% ] waiting    07m35.0s
+get_categories            • [   0% ] waiting    10m05.0s
+
+running (02m26.0s), 14/16 VUs, 17 complete and 0 interrupted iterations
+full_text_search            [  97% ] 14/15 VUs  2m26.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m04.0s
+multi_field_search        • [   0% ] waiting    2m34.0s
+autocomplete              • [   0% ] waiting    5m04.0s
+get_by_id                 • [   0% ] waiting    07m34.0s
+get_categories            • [   0% ] waiting    10m04.0s
+
+running (02m27.0s), 14/16 VUs, 17 complete and 0 interrupted iterations
+full_text_search            [  98% ] 14/15 VUs  2m27.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m03.0s
+multi_field_search        • [   0% ] waiting    2m33.0s
+autocomplete              • [   0% ] waiting    5m03.0s
+get_by_id                 • [   0% ] waiting    07m33.0s
+get_categories            • [   0% ] waiting    10m03.0s
+time="2026-03-12T14:22:42Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=bronze%20ring&size=20&page=4\": request timeout"
+
+running (02m28.0s), 14/16 VUs, 17 complete and 0 interrupted iterations
+full_text_search            [  99% ] 14/15 VUs  2m28.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m02.0s
+multi_field_search        • [   0% ] waiting    2m32.0s
+autocomplete              • [   0% ] waiting    5m02.0s
+get_by_id                 • [   0% ] waiting    07m32.0s
+get_categories            • [   0% ] waiting    10m02.0s
+
+running (02m29.0s), 13/16 VUs, 18 complete and 0 interrupted iterations
+full_text_search            [  99% ] 13/15 VUs  2m29.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m01.0s
+multi_field_search        • [   0% ] waiting    2m31.0s
+autocomplete              • [   0% ] waiting    5m01.0s
+get_by_id                 • [   0% ] waiting    07m31.0s
+get_categories            • [   0% ] waiting    10m01.0s
+
+running (02m30.0s), 13/16 VUs, 18 complete and 0 interrupted iterations
+full_text_search            [ 100% ] 13/15 VUs  2m30.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m00.0s
+multi_field_search        • [   0% ] waiting    2m30.0s
+autocomplete              • [   0% ] waiting    5m00.0s
+get_by_id                 • [   0% ] waiting    07m30.0s
+get_categories            • [   0% ] waiting    10m00.0s
+time="2026-03-12T14:22:45Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=ceramic%20mug&size=20&page=1\": request timeout"
+
+running (02m31.0s), 14/16 VUs, 18 complete and 0 interrupted iterations
+full_text_search          ↓ [ 100% ] 13/15 VUs  2m30s
+filtered_sorted_paginated   [   1% ] 01/15 VUs  0m01.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    2m29.0s
+autocomplete              • [   0% ] waiting    4m59.0s
+get_by_id                 • [   0% ] waiting    07m29.0s
+get_categories            • [   0% ] waiting    09m59.0s
+time="2026-03-12T14:22:46Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=suede%20boots&size=20&page=4\": request timeout"
+
+running (02m32.0s), 13/16 VUs, 19 complete and 0 interrupted iterations
+full_text_search          ↓ [ 100% ] 13/15 VUs  2m30s
+filtered_sorted_paginated   [   1% ] 01/15 VUs  0m02.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    2m28.0s
+autocomplete              • [   0% ] waiting    4m58.0s
+get_by_id                 • [   0% ] waiting    07m28.0s
+get_categories            • [   0% ] waiting    09m58.0s
+
+running (02m33.0s), 12/16 VUs, 20 complete and 0 interrupted iterations
+full_text_search          ↓ [ 100% ] 13/15 VUs  2m30s
+filtered_sorted_paginated   [   2% ] 01/15 VUs  0m03.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    2m27.0s
+autocomplete              • [   0% ] waiting    4m57.0s
+get_by_id                 • [   0% ] waiting    07m27.0s
+get_categories            • [   0% ] waiting    09m57.0s
+time="2026-03-12T14:22:48Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=crystal%20earrings&size=20&page=3\": request timeout"
+
+running (02m34.0s), 11/16 VUs, 21 complete and 0 interrupted iterations
+full_text_search          ↓ [ 100% ] 13/15 VUs  2m30s
+filtered_sorted_paginated   [   3% ] 01/15 VUs  0m04.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    2m26.0s
+autocomplete              • [   0% ] waiting    4m56.0s
+get_by_id                 • [   0% ] waiting    07m26.0s
+get_categories            • [   0% ] waiting    09m56.0s
+
+running (02m35.0s), 10/16 VUs, 22 complete and 0 interrupted iterations
+full_text_search          ↓ [ 100% ] 13/15 VUs  2m30s
+filtered_sorted_paginated   [   3% ] 01/15 VUs  0m05.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    2m25.0s
+autocomplete              • [   0% ] waiting    4m55.0s
+get_by_id                 • [   0% ] waiting    07m25.0s
+get_categories            • [   0% ] waiting    09m55.0s
+
+running (02m36.0s), 10/16 VUs, 22 complete and 0 interrupted iterations
+full_text_search          ↓ [ 100% ] 13/15 VUs  2m30s
+filtered_sorted_paginated   [   4% ] 01/15 VUs  0m06.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    2m24.0s
+autocomplete              • [   0% ] waiting    4m54.0s
+get_by_id                 • [   0% ] waiting    07m24.0s
+get_categories            • [   0% ] waiting    09m54.0s
+time="2026-03-12T14:22:51Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=steel%20belt&size=20&page=0\": request timeout"
+
+running (02m37.0s), 10/16 VUs, 22 complete and 0 interrupted iterations
+full_text_search          ↓ [ 100% ] 13/15 VUs  2m30s
+filtered_sorted_paginated   [   5% ] 01/15 VUs  0m07.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    2m23.0s
+autocomplete              • [   0% ] waiting    4m53.0s
+get_by_id                 • [   0% ] waiting    07m23.0s
+get_categories            • [   0% ] waiting    09m53.0s
+
+running (02m38.0s), 09/16 VUs, 23 complete and 0 interrupted iterations
+full_text_search          ↓ [ 100% ] 13/15 VUs  2m30s
+filtered_sorted_paginated   [   5% ] 01/15 VUs  0m08.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    2m22.0s
+autocomplete              • [   0% ] waiting    4m52.0s
+get_by_id                 • [   0% ] waiting    07m22.0s
+get_categories            • [   0% ] waiting    09m52.0s
+time="2026-03-12T14:22:53Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=bamboo%20bottle&size=20&page=3\": request timeout"
+
+running (02m39.0s), 09/16 VUs, 23 complete and 0 interrupted iterations
+full_text_search          ↓ [ 100% ] 13/15 VUs  2m30s
+filtered_sorted_paginated   [   6% ] 01/15 VUs  0m09.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    2m21.0s
+autocomplete              • [   0% ] waiting    4m51.0s
+get_by_id                 • [   0% ] waiting    07m21.0s
+get_categories            • [   0% ] waiting    09m51.0s
+
+running (02m40.0s), 08/16 VUs, 24 complete and 0 interrupted iterations
+full_text_search          ↓ [ 100% ] 13/15 VUs  2m30s
+filtered_sorted_paginated   [   7% ] 01/15 VUs  0m10.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    2m20.0s
+autocomplete              • [   0% ] waiting    4m50.0s
+get_by_id                 • [   0% ] waiting    07m20.0s
+get_categories            • [   0% ] waiting    09m50.0s
+
+running (02m41.0s), 08/16 VUs, 24 complete and 0 interrupted iterations
+full_text_search          ↓ [ 100% ] 13/15 VUs  2m30s
+filtered_sorted_paginated   [   7% ] 01/15 VUs  0m11.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    2m19.0s
+autocomplete              • [   0% ] waiting    4m49.0s
+get_by_id                 • [   0% ] waiting    07m19.0s
+get_categories            • [   0% ] waiting    09m49.0s
+
+running (02m42.0s), 07/16 VUs, 25 complete and 0 interrupted iterations
+full_text_search          ↓ [ 100% ] 13/15 VUs  2m30s
+filtered_sorted_paginated   [   8% ] 01/15 VUs  0m12.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    2m18.0s
+autocomplete              • [   0% ] waiting    4m48.0s
+get_by_id                 • [   0% ] waiting    07m18.0s
+get_categories            • [   0% ] waiting    09m48.0s
+
+running (02m43.0s), 07/16 VUs, 25 complete and 0 interrupted iterations
+full_text_search          ↓ [ 100% ] 13/15 VUs  2m30s
+filtered_sorted_paginated   [   9% ] 01/15 VUs  0m13.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    2m17.0s
+autocomplete              • [   0% ] waiting    4m47.0s
+get_by_id                 • [   0% ] waiting    07m17.0s
+get_categories            • [   0% ] waiting    09m47.0s
+
+running (02m44.0s), 07/16 VUs, 25 complete and 0 interrupted iterations
+full_text_search          ↓ [ 100% ] 13/15 VUs  2m30s
+filtered_sorted_paginated   [   9% ] 01/15 VUs  0m14.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    2m16.0s
+autocomplete              • [   0% ] waiting    4m46.0s
+get_by_id                 • [   0% ] waiting    07m16.0s
+get_categories            • [   0% ] waiting    09m46.0s
+
+running (02m45.0s), 06/16 VUs, 26 complete and 0 interrupted iterations
+full_text_search          ↓ [ 100% ] 13/15 VUs  2m30s
+filtered_sorted_paginated   [  10% ] 01/15 VUs  0m15.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    2m15.0s
+autocomplete              • [   0% ] waiting    4m45.0s
+get_by_id                 • [   0% ] waiting    07m15.0s
+get_categories            • [   0% ] waiting    09m45.0s
+
+running (02m46.0s), 06/16 VUs, 26 complete and 0 interrupted iterations
+full_text_search          ↓ [ 100% ] 13/15 VUs  2m30s
+filtered_sorted_paginated   [  11% ] 01/15 VUs  0m16.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    2m14.0s
+autocomplete              • [   0% ] waiting    4m44.0s
+get_by_id                 • [   0% ] waiting    07m14.0s
+get_categories            • [   0% ] waiting    09m44.0s
+
+running (02m47.0s), 05/16 VUs, 26 complete and 1 interrupted iterations
+full_text_search          ↓ [ 100% ] 13/15 VUs  2m30s
+filtered_sorted_paginated   [  11% ] 01/15 VUs  0m17.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    2m13.0s
+autocomplete              • [   0% ] waiting    4m43.0s
+get_by_id                 • [   0% ] waiting    07m13.0s
+get_categories            • [   0% ] waiting    09m43.0s
+
+running (02m48.0s), 05/16 VUs, 26 complete and 1 interrupted iterations
+full_text_search          ↓ [ 100% ] 13/15 VUs  2m30s
+filtered_sorted_paginated   [  12% ] 01/15 VUs  0m18.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    2m12.0s
+autocomplete              • [   0% ] waiting    4m42.0s
+get_by_id                 • [   0% ] waiting    07m12.0s
+get_categories            • [   0% ] waiting    09m42.0s
+
+running (02m49.0s), 05/16 VUs, 26 complete and 1 interrupted iterations
+full_text_search          ↓ [ 100% ] 13/15 VUs  2m30s
+filtered_sorted_paginated   [  13% ] 01/15 VUs  0m19.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    2m11.0s
+autocomplete              • [   0% ] waiting    4m41.0s
+get_by_id                 • [   0% ] waiting    07m11.0s
+get_categories            • [   0% ] waiting    09m41.0s
+
+running (02m50.0s), 04/16 VUs, 27 complete and 1 interrupted iterations
+full_text_search          ↓ [ 100% ] 13/15 VUs  2m30s
+filtered_sorted_paginated   [  13% ] 01/15 VUs  0m20.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    2m10.0s
+autocomplete              • [   0% ] waiting    4m40.0s
+get_by_id                 • [   0% ] waiting    07m10.0s
+get_categories            • [   0% ] waiting    09m40.0s
+
+running (02m51.0s), 04/16 VUs, 27 complete and 1 interrupted iterations
+full_text_search          ↓ [ 100% ] 13/15 VUs  2m30s
+filtered_sorted_paginated   [  14% ] 01/15 VUs  0m21.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    2m09.0s
+autocomplete              • [   0% ] waiting    4m39.0s
+get_by_id                 • [   0% ] waiting    07m09.0s
+get_categories            • [   0% ] waiting    09m39.0s
+
+running (02m52.0s), 03/16 VUs, 28 complete and 1 interrupted iterations
+full_text_search          ↓ [ 100% ] 13/15 VUs  2m30s
+filtered_sorted_paginated   [  15% ] 01/15 VUs  0m22.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    2m08.0s
+autocomplete              • [   0% ] waiting    4m38.0s
+get_by_id                 • [   0% ] waiting    07m08.0s
+get_categories            • [   0% ] waiting    09m38.0s
+time="2026-03-12T14:23:07Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?categoryName=Kitchen%20%26%20Dining&minPrice=507&maxPrice=3874&sortBy=price&sortDir=asc&size=20&page=4\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (02m53.0s), 04/16 VUs, 28 complete and 1 interrupted iterations
+full_text_search          ↓ [ 100% ] 13/15 VUs  2m30s
+filtered_sorted_paginated   [  15% ] 02/15 VUs  0m23.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    2m07.0s
+autocomplete              • [   0% ] waiting    4m37.0s
+get_by_id                 • [   0% ] waiting    07m07.0s
+get_categories            • [   0% ] waiting    09m37.0s
+
+running (02m54.0s), 04/16 VUs, 29 complete and 1 interrupted iterations
+full_text_search          ↓ [ 100% ] 13/15 VUs  2m30s
+filtered_sorted_paginated   [  16% ] 02/15 VUs  0m24.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    2m06.0s
+autocomplete              • [   0% ] waiting    4m36.0s
+get_by_id                 • [   0% ] waiting    07m06.0s
+get_categories            • [   0% ] waiting    09m36.0s
+
+running (02m55.0s), 03/16 VUs, 29 complete and 2 interrupted iterations
+full_text_search          ↓ [ 100% ] 13/15 VUs  2m30s
+filtered_sorted_paginated   [  17% ] 02/15 VUs  0m25.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    2m05.0s
+autocomplete              • [   0% ] waiting    4m35.0s
+get_by_id                 • [   0% ] waiting    07m05.0s
+get_categories            • [   0% ] waiting    09m35.0s
+
+running (02m56.0s), 03/16 VUs, 29 complete and 2 interrupted iterations
+full_text_search          ↓ [ 100% ] 13/15 VUs  2m30s
+filtered_sorted_paginated   [  17% ] 02/15 VUs  0m26.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    2m04.0s
+autocomplete              • [   0% ] waiting    4m34.0s
+get_by_id                 • [   0% ] waiting    07m04.0s
+get_categories            • [   0% ] waiting    09m34.0s
+
+running (02m57.0s), 03/16 VUs, 29 complete and 2 interrupted iterations
+full_text_search          ↓ [ 100% ] 13/15 VUs  2m30s
+filtered_sorted_paginated   [  18% ] 02/15 VUs  0m27.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    2m03.0s
+autocomplete              • [   0% ] waiting    4m33.0s
+get_by_id                 • [   0% ] waiting    07m03.0s
+get_categories            • [   0% ] waiting    09m33.0s
+
+running (02m58.0s), 03/16 VUs, 29 complete and 2 interrupted iterations
+full_text_search          ↓ [ 100% ] 13/15 VUs  2m30s
+filtered_sorted_paginated   [  19% ] 02/15 VUs  0m28.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    2m02.0s
+autocomplete              • [   0% ] waiting    4m32.0s
+get_by_id                 • [   0% ] waiting    07m02.0s
+get_categories            • [   0% ] waiting    09m32.0s
+
+running (02m59.0s), 03/16 VUs, 29 complete and 2 interrupted iterations
+full_text_search          ↓ [ 100% ] 13/15 VUs  2m30s
+filtered_sorted_paginated   [  19% ] 02/15 VUs  0m29.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    2m01.0s
+autocomplete              • [   0% ] waiting    4m31.0s
+get_by_id                 • [   0% ] waiting    07m01.0s
+get_categories            • [   0% ] waiting    09m31.0s
+
+running (03m00.0s), 02/16 VUs, 29 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  20% ] 02/15 VUs  0m30.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    2m00.0s
+autocomplete              • [   0% ] waiting    4m30.0s
+get_by_id                 • [   0% ] waiting    07m00.0s
+get_categories            • [   0% ] waiting    09m30.0s
+
+running (03m01.0s), 03/16 VUs, 29 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  21% ] 03/15 VUs  0m31.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m59.0s
+autocomplete              • [   0% ] waiting    4m29.0s
+get_by_id                 • [   0% ] waiting    06m59.0s
+get_categories            • [   0% ] waiting    09m29.0s
+
+running (03m02.0s), 03/16 VUs, 29 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  21% ] 03/15 VUs  0m32.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m58.0s
+autocomplete              • [   0% ] waiting    4m28.0s
+get_by_id                 • [   0% ] waiting    06m58.0s
+get_categories            • [   0% ] waiting    09m28.0s
+
+running (03m03.0s), 03/16 VUs, 29 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  22% ] 03/15 VUs  0m33.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m57.0s
+autocomplete              • [   0% ] waiting    4m27.0s
+get_by_id                 • [   0% ] waiting    06m57.0s
+get_categories            • [   0% ] waiting    09m27.0s
+
+running (03m04.0s), 03/16 VUs, 29 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  23% ] 03/15 VUs  0m34.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m56.0s
+autocomplete              • [   0% ] waiting    4m26.0s
+get_by_id                 • [   0% ] waiting    06m56.0s
+get_categories            • [   0% ] waiting    09m26.0s
+
+running (03m05.0s), 03/16 VUs, 29 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  23% ] 03/15 VUs  0m35.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m55.0s
+autocomplete              • [   0% ] waiting    4m25.0s
+get_by_id                 • [   0% ] waiting    06m55.0s
+get_categories            • [   0% ] waiting    09m25.0s
+
+running (03m06.0s), 03/16 VUs, 29 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  24% ] 03/15 VUs  0m36.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m54.0s
+autocomplete              • [   0% ] waiting    4m24.0s
+get_by_id                 • [   0% ] waiting    06m54.0s
+get_categories            • [   0% ] waiting    09m24.0s
+
+running (03m07.0s), 03/16 VUs, 29 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  25% ] 03/15 VUs  0m37.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m53.0s
+autocomplete              • [   0% ] waiting    4m23.0s
+get_by_id                 • [   0% ] waiting    06m53.0s
+get_categories            • [   0% ] waiting    09m23.0s
+time="2026-03-12T14:23:22Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?categoryName=Furniture&minPrice=503&maxPrice=4569&sortBy=price&sortDir=asc&size=20&page=6\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (03m08.0s), 04/16 VUs, 29 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  25% ] 04/15 VUs  0m38.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m52.0s
+autocomplete              • [   0% ] waiting    4m22.0s
+get_by_id                 • [   0% ] waiting    06m52.0s
+get_categories            • [   0% ] waiting    09m22.0s
+time="2026-03-12T14:23:23Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?categoryName=Women's%20Clothing&minPrice=75&maxPrice=2879&sortBy=price&sortDir=desc&size=20&page=6\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (03m09.0s), 04/16 VUs, 30 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  26% ] 04/15 VUs  0m39.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m51.0s
+autocomplete              • [   0% ] waiting    4m21.0s
+get_by_id                 • [   0% ] waiting    06m51.0s
+get_categories            • [   0% ] waiting    09m21.0s
+time="2026-03-12T14:23:24Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?categoryName=Beauty%20%26%20Personal%20Care&minPrice=500&maxPrice=2882&sortBy=price&sortDir=desc&size=20&page=2\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (03m10.0s), 04/16 VUs, 31 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  27% ] 04/15 VUs  0m40.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m50.0s
+autocomplete              • [   0% ] waiting    4m20.0s
+get_by_id                 • [   0% ] waiting    06m50.0s
+get_categories            • [   0% ] waiting    09m20.0s
+time="2026-03-12T14:23:25Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?categoryName=Jewelry&minPrice=546&maxPrice=4604&sortBy=price&sortDir=desc&size=20&page=6\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (03m11.0s), 04/16 VUs, 32 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  27% ] 04/15 VUs  0m41.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m49.0s
+autocomplete              • [   0% ] waiting    4m19.0s
+get_by_id                 • [   0% ] waiting    06m49.0s
+get_categories            • [   0% ] waiting    09m19.0s
+
+running (03m12.0s), 04/16 VUs, 33 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  28% ] 04/15 VUs  0m42.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m48.0s
+autocomplete              • [   0% ] waiting    4m18.0s
+get_by_id                 • [   0% ] waiting    06m48.0s
+get_categories            • [   0% ] waiting    09m18.0s
+
+running (03m13.0s), 04/16 VUs, 33 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  29% ] 04/15 VUs  0m43.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m47.0s
+autocomplete              • [   0% ] waiting    4m17.0s
+get_by_id                 • [   0% ] waiting    06m47.0s
+get_categories            • [   0% ] waiting    09m17.0s
+
+running (03m14.0s), 04/16 VUs, 33 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  29% ] 04/15 VUs  0m44.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m46.0s
+autocomplete              • [   0% ] waiting    4m16.0s
+get_by_id                 • [   0% ] waiting    06m46.0s
+get_categories            • [   0% ] waiting    09m16.0s
+
+running (03m15.0s), 04/16 VUs, 33 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  30% ] 04/15 VUs  0m45.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m45.0s
+autocomplete              • [   0% ] waiting    4m15.0s
+get_by_id                 • [   0% ] waiting    06m45.0s
+get_categories            • [   0% ] waiting    09m15.0s
+
+running (03m16.0s), 05/16 VUs, 33 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  31% ] 05/15 VUs  0m46.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m44.0s
+autocomplete              • [   0% ] waiting    4m14.0s
+get_by_id                 • [   0% ] waiting    06m44.0s
+get_categories            • [   0% ] waiting    09m14.0s
+
+running (03m17.0s), 05/16 VUs, 33 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  31% ] 05/15 VUs  0m47.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m43.0s
+autocomplete              • [   0% ] waiting    4m13.0s
+get_by_id                 • [   0% ] waiting    06m43.0s
+get_categories            • [   0% ] waiting    09m13.0s
+
+running (03m18.0s), 05/16 VUs, 33 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  32% ] 05/15 VUs  0m48.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m42.0s
+autocomplete              • [   0% ] waiting    4m12.0s
+get_by_id                 • [   0% ] waiting    06m42.0s
+get_categories            • [   0% ] waiting    09m12.0s
+
+running (03m19.0s), 05/16 VUs, 33 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  33% ] 05/15 VUs  0m49.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m41.0s
+autocomplete              • [   0% ] waiting    4m11.0s
+get_by_id                 • [   0% ] waiting    06m41.0s
+get_categories            • [   0% ] waiting    09m11.0s
+
+running (03m20.0s), 05/16 VUs, 33 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  33% ] 05/15 VUs  0m50.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m40.0s
+autocomplete              • [   0% ] waiting    4m10.0s
+get_by_id                 • [   0% ] waiting    06m40.0s
+get_categories            • [   0% ] waiting    09m10.0s
+
+running (03m21.0s), 05/16 VUs, 33 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  34% ] 05/15 VUs  0m51.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m39.0s
+autocomplete              • [   0% ] waiting    4m09.0s
+get_by_id                 • [   0% ] waiting    06m39.0s
+get_categories            • [   0% ] waiting    09m09.0s
+
+running (03m22.0s), 05/16 VUs, 33 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  35% ] 05/15 VUs  0m52.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m38.0s
+autocomplete              • [   0% ] waiting    4m08.0s
+get_by_id                 • [   0% ] waiting    06m38.0s
+get_categories            • [   0% ] waiting    09m08.0s
+
+running (03m23.0s), 05/16 VUs, 33 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  35% ] 05/15 VUs  0m53.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m37.0s
+autocomplete              • [   0% ] waiting    4m07.0s
+get_by_id                 • [   0% ] waiting    06m37.0s
+get_categories            • [   0% ] waiting    09m07.0s
+
+running (03m24.0s), 05/16 VUs, 33 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  36% ] 05/15 VUs  0m54.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m36.0s
+autocomplete              • [   0% ] waiting    4m06.0s
+get_by_id                 • [   0% ] waiting    06m36.0s
+get_categories            • [   0% ] waiting    09m06.0s
+
+running (03m25.0s), 05/16 VUs, 34 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  37% ] 05/15 VUs  0m55.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m35.0s
+autocomplete              • [   0% ] waiting    4m05.0s
+get_by_id                 • [   0% ] waiting    06m35.0s
+get_categories            • [   0% ] waiting    09m05.0s
+
+running (03m26.0s), 05/16 VUs, 34 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  37% ] 05/15 VUs  0m56.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m34.0s
+autocomplete              • [   0% ] waiting    4m04.0s
+get_by_id                 • [   0% ] waiting    06m34.0s
+get_categories            • [   0% ] waiting    09m04.0s
+
+running (03m27.0s), 05/16 VUs, 34 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  38% ] 05/15 VUs  0m57.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m33.0s
+autocomplete              • [   0% ] waiting    4m03.0s
+get_by_id                 • [   0% ] waiting    06m33.0s
+get_categories            • [   0% ] waiting    09m03.0s
+
+running (03m28.0s), 05/16 VUs, 34 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  39% ] 05/15 VUs  0m58.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m32.0s
+autocomplete              • [   0% ] waiting    4m02.0s
+get_by_id                 • [   0% ] waiting    06m32.0s
+get_categories            • [   0% ] waiting    09m02.0s
+
+running (03m29.0s), 05/16 VUs, 34 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  39% ] 05/15 VUs  0m59.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m31.0s
+autocomplete              • [   0% ] waiting    4m01.0s
+get_by_id                 • [   0% ] waiting    06m31.0s
+get_categories            • [   0% ] waiting    09m01.0s
+
+running (03m30.0s), 05/16 VUs, 34 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  40% ] 05/15 VUs  1m00.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m30.0s
+autocomplete              • [   0% ] waiting    4m00.0s
+get_by_id                 • [   0% ] waiting    06m30.0s
+get_categories            • [   0% ] waiting    09m00.0s
+time="2026-03-12T14:23:45Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?categoryName=Kitchen%20%26%20Dining&minPrice=290&maxPrice=3274&sortBy=price&sortDir=desc&size=20&page=5\": request timeout"
+
+running (03m31.0s), 05/16 VUs, 34 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  41% ] 05/15 VUs  1m01.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m29.0s
+autocomplete              • [   0% ] waiting    3m59.0s
+get_by_id                 • [   0% ] waiting    06m29.0s
+get_categories            • [   0% ] waiting    08m59.0s
+time="2026-03-12T14:23:46Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?categoryName=Kitchen%20%26%20Dining&minPrice=484&maxPrice=5980&sortBy=price&sortDir=asc&size=20&page=0\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (03m32.0s), 05/16 VUs, 36 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  41% ] 05/15 VUs  1m02.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m28.0s
+autocomplete              • [   0% ] waiting    3m58.0s
+get_by_id                 • [   0% ] waiting    06m28.0s
+get_categories            • [   0% ] waiting    08m58.0s
+
+running (03m33.0s), 05/16 VUs, 37 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  42% ] 05/15 VUs  1m03.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m27.0s
+autocomplete              • [   0% ] waiting    3m57.0s
+get_by_id                 • [   0% ] waiting    06m27.0s
+get_categories            • [   0% ] waiting    08m57.0s
+
+running (03m34.0s), 05/16 VUs, 37 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  43% ] 05/15 VUs  1m04.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m26.0s
+autocomplete              • [   0% ] waiting    3m56.0s
+get_by_id                 • [   0% ] waiting    06m26.0s
+get_categories            • [   0% ] waiting    08m56.0s
+
+running (03m35.0s), 05/16 VUs, 37 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  43% ] 05/15 VUs  1m05.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m25.0s
+autocomplete              • [   0% ] waiting    3m55.0s
+get_by_id                 • [   0% ] waiting    06m25.0s
+get_categories            • [   0% ] waiting    08m55.0s
+
+running (03m36.0s), 05/16 VUs, 37 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  44% ] 05/15 VUs  1m06.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m24.0s
+autocomplete              • [   0% ] waiting    3m54.0s
+get_by_id                 • [   0% ] waiting    06m24.0s
+get_categories            • [   0% ] waiting    08m54.0s
+
+running (03m37.0s), 05/16 VUs, 37 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  45% ] 05/15 VUs  1m07.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m23.0s
+autocomplete              • [   0% ] waiting    3m53.0s
+get_by_id                 • [   0% ] waiting    06m23.0s
+get_categories            • [   0% ] waiting    08m53.0s
+
+running (03m38.0s), 05/16 VUs, 37 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  45% ] 05/15 VUs  1m08.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m22.0s
+autocomplete              • [   0% ] waiting    3m52.0s
+get_by_id                 • [   0% ] waiting    06m22.0s
+get_categories            • [   0% ] waiting    08m52.0s
+
+running (03m39.0s), 05/16 VUs, 37 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  46% ] 05/15 VUs  1m09.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m21.0s
+autocomplete              • [   0% ] waiting    3m51.0s
+get_by_id                 • [   0% ] waiting    06m21.0s
+get_categories            • [   0% ] waiting    08m51.0s
+
+running (03m40.0s), 05/16 VUs, 37 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  47% ] 05/15 VUs  1m10.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m20.0s
+autocomplete              • [   0% ] waiting    3m50.0s
+get_by_id                 • [   0% ] waiting    06m20.0s
+get_categories            • [   0% ] waiting    08m50.0s
+
+running (03m41.0s), 05/16 VUs, 37 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  47% ] 05/15 VUs  1m11.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m19.0s
+autocomplete              • [   0% ] waiting    3m49.0s
+get_by_id                 • [   0% ] waiting    06m19.0s
+get_categories            • [   0% ] waiting    08m49.0s
+
+running (03m42.0s), 05/16 VUs, 37 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  48% ] 05/15 VUs  1m12.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m18.0s
+autocomplete              • [   0% ] waiting    3m48.0s
+get_by_id                 • [   0% ] waiting    06m18.0s
+get_categories            • [   0% ] waiting    08m48.0s
+
+running (03m43.0s), 05/16 VUs, 38 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  49% ] 05/15 VUs  1m13.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m17.0s
+autocomplete              • [   0% ] waiting    3m47.0s
+get_by_id                 • [   0% ] waiting    06m17.0s
+get_categories            • [   0% ] waiting    08m47.0s
+
+running (03m44.0s), 05/16 VUs, 38 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  49% ] 05/15 VUs  1m14.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m16.0s
+autocomplete              • [   0% ] waiting    3m46.0s
+get_by_id                 • [   0% ] waiting    06m16.0s
+get_categories            • [   0% ] waiting    08m46.0s
+
+running (03m45.0s), 05/16 VUs, 38 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  50% ] 05/15 VUs  1m15.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m15.0s
+autocomplete              • [   0% ] waiting    3m45.0s
+get_by_id                 • [   0% ] waiting    06m15.0s
+get_categories            • [   0% ] waiting    08m45.0s
+
+running (03m46.0s), 05/16 VUs, 38 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  51% ] 05/15 VUs  1m16.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m14.0s
+autocomplete              • [   0% ] waiting    3m44.0s
+get_by_id                 • [   0% ] waiting    06m14.0s
+get_categories            • [   0% ] waiting    08m44.0s
+
+running (03m47.0s), 05/16 VUs, 39 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  51% ] 05/15 VUs  1m17.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m13.0s
+autocomplete              • [   0% ] waiting    3m43.0s
+get_by_id                 • [   0% ] waiting    06m13.0s
+get_categories            • [   0% ] waiting    08m43.0s
+
+running (03m48.0s), 05/16 VUs, 39 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  52% ] 05/15 VUs  1m18.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m12.0s
+autocomplete              • [   0% ] waiting    3m42.0s
+get_by_id                 • [   0% ] waiting    06m12.0s
+get_categories            • [   0% ] waiting    08m42.0s
+time="2026-03-12T14:24:03Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?categoryName=Furniture&minPrice=331&maxPrice=3455&sortBy=price&sortDir=desc&size=20&page=9\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (03m49.0s), 06/16 VUs, 39 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  53% ] 06/15 VUs  1m19.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m11.0s
+autocomplete              • [   0% ] waiting    3m41.0s
+get_by_id                 • [   0% ] waiting    06m11.0s
+get_categories            • [   0% ] waiting    08m41.0s
+
+running (03m50.0s), 06/16 VUs, 40 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  53% ] 06/15 VUs  1m20.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m10.0s
+autocomplete              • [   0% ] waiting    3m40.0s
+get_by_id                 • [   0% ] waiting    06m10.0s
+get_categories            • [   0% ] waiting    08m40.0s
+
+running (03m51.0s), 06/16 VUs, 40 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  54% ] 06/15 VUs  1m21.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m09.0s
+autocomplete              • [   0% ] waiting    3m39.0s
+get_by_id                 • [   0% ] waiting    06m09.0s
+get_categories            • [   0% ] waiting    08m39.0s
+time="2026-03-12T14:24:06Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?categoryName=Electronics%20Accessories&minPrice=514&maxPrice=1078&sortBy=price&sortDir=desc&size=20&page=2\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (03m52.0s), 07/16 VUs, 40 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  55% ] 07/15 VUs  1m22.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m08.0s
+autocomplete              • [   0% ] waiting    3m38.0s
+get_by_id                 • [   0% ] waiting    06m08.0s
+get_categories            • [   0% ] waiting    08m38.0s
+
+running (03m53.0s), 07/16 VUs, 41 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  55% ] 07/15 VUs  1m23.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m07.0s
+autocomplete              • [   0% ] waiting    3m37.0s
+get_by_id                 • [   0% ] waiting    06m07.0s
+get_categories            • [   0% ] waiting    08m37.0s
+
+running (03m54.0s), 07/16 VUs, 41 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  56% ] 07/15 VUs  1m24.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m06.0s
+autocomplete              • [   0% ] waiting    3m36.0s
+get_by_id                 • [   0% ] waiting    06m06.0s
+get_categories            • [   0% ] waiting    08m36.0s
+
+running (03m55.0s), 08/16 VUs, 41 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  57% ] 08/15 VUs  1m25.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m05.0s
+autocomplete              • [   0% ] waiting    3m35.0s
+get_by_id                 • [   0% ] waiting    06m05.0s
+get_categories            • [   0% ] waiting    08m35.0s
+
+running (03m56.0s), 08/16 VUs, 42 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  57% ] 08/15 VUs  1m26.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m04.0s
+autocomplete              • [   0% ] waiting    3m34.0s
+get_by_id                 • [   0% ] waiting    06m04.0s
+get_categories            • [   0% ] waiting    08m34.0s
+
+running (03m57.0s), 08/16 VUs, 42 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  58% ] 08/15 VUs  1m27.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m03.0s
+autocomplete              • [   0% ] waiting    3m33.0s
+get_by_id                 • [   0% ] waiting    06m03.0s
+get_categories            • [   0% ] waiting    08m33.0s
+time="2026-03-12T14:24:12Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?categoryName=Sports%20%26%20Outdoors&minPrice=402&maxPrice=2878&sortBy=price&sortDir=desc&size=20&page=8\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (03m58.0s), 09/16 VUs, 42 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  59% ] 09/15 VUs  1m28.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m02.0s
+autocomplete              • [   0% ] waiting    3m32.0s
+get_by_id                 • [   0% ] waiting    06m02.0s
+get_categories            • [   0% ] waiting    08m32.0s
+time="2026-03-12T14:24:13Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?categoryName=Men's%20Clothing&minPrice=415&maxPrice=1883&sortBy=price&sortDir=asc&size=20&page=8\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (03m59.0s), 09/16 VUs, 43 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  59% ] 09/15 VUs  1m29.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m01.0s
+autocomplete              • [   0% ] waiting    3m31.0s
+get_by_id                 • [   0% ] waiting    06m01.0s
+get_categories            • [   0% ] waiting    08m31.0s
+
+running (04m00.0s), 09/16 VUs, 44 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  60% ] 09/15 VUs  1m30.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m00.0s
+autocomplete              • [   0% ] waiting    3m30.0s
+get_by_id                 • [   0% ] waiting    06m00.0s
+get_categories            • [   0% ] waiting    08m30.0s
+
+running (04m01.0s), 10/16 VUs, 44 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  61% ] 10/15 VUs  1m31.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m59.0s
+autocomplete              • [   0% ] waiting    3m29.0s
+get_by_id                 • [   0% ] waiting    05m59.0s
+get_categories            • [   0% ] waiting    08m29.0s
+
+running (04m02.0s), 10/16 VUs, 44 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  61% ] 10/15 VUs  1m32.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m58.0s
+autocomplete              • [   0% ] waiting    3m28.0s
+get_by_id                 • [   0% ] waiting    05m58.0s
+get_categories            • [   0% ] waiting    08m28.0s
+
+running (04m03.0s), 10/16 VUs, 45 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  62% ] 10/15 VUs  1m33.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m57.0s
+autocomplete              • [   0% ] waiting    3m27.0s
+get_by_id                 • [   0% ] waiting    05m57.0s
+get_categories            • [   0% ] waiting    08m27.0s
+
+running (04m04.0s), 11/16 VUs, 46 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  63% ] 11/15 VUs  1m34.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m56.0s
+autocomplete              • [   0% ] waiting    3m26.0s
+get_by_id                 • [   0% ] waiting    05m56.0s
+get_categories            • [   0% ] waiting    08m26.0s
+
+running (04m05.0s), 11/16 VUs, 46 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  63% ] 11/15 VUs  1m35.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m55.0s
+autocomplete              • [   0% ] waiting    3m25.0s
+get_by_id                 • [   0% ] waiting    05m55.0s
+get_categories            • [   0% ] waiting    08m25.0s
+
+running (04m06.0s), 11/16 VUs, 46 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  64% ] 11/15 VUs  1m36.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m54.0s
+autocomplete              • [   0% ] waiting    3m24.0s
+get_by_id                 • [   0% ] waiting    05m54.0s
+get_categories            • [   0% ] waiting    08m24.0s
+time="2026-03-12T14:24:21Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?categoryName=Footwear&minPrice=275&maxPrice=2623&sortBy=price&sortDir=asc&size=20&page=4\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (04m07.0s), 12/16 VUs, 46 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  65% ] 12/15 VUs  1m37.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m53.0s
+autocomplete              • [   0% ] waiting    3m23.0s
+get_by_id                 • [   0% ] waiting    05m53.0s
+get_categories            • [   0% ] waiting    08m23.0s
+
+running (04m08.0s), 12/16 VUs, 47 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  65% ] 12/15 VUs  1m38.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m52.0s
+autocomplete              • [   0% ] waiting    3m22.0s
+get_by_id                 • [   0% ] waiting    05m52.0s
+get_categories            • [   0% ] waiting    08m22.0s
+
+running (04m09.0s), 12/16 VUs, 47 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  66% ] 12/15 VUs  1m39.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m51.0s
+autocomplete              • [   0% ] waiting    3m21.0s
+get_by_id                 • [   0% ] waiting    05m51.0s
+get_categories            • [   0% ] waiting    08m21.0s
+time="2026-03-12T14:24:24Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?categoryName=Women's%20Clothing&minPrice=188&maxPrice=1462&sortBy=price&sortDir=desc&size=20&page=6\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (04m10.0s), 13/16 VUs, 47 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  67% ] 13/15 VUs  1m40.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m50.0s
+autocomplete              • [   0% ] waiting    3m20.0s
+get_by_id                 • [   0% ] waiting    05m50.0s
+get_categories            • [   0% ] waiting    08m20.0s
+
+running (04m11.0s), 13/16 VUs, 48 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  67% ] 13/15 VUs  1m41.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m49.0s
+autocomplete              • [   0% ] waiting    3m19.0s
+get_by_id                 • [   0% ] waiting    05m49.0s
+get_categories            • [   0% ] waiting    08m19.0s
+
+running (04m12.0s), 13/16 VUs, 48 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  68% ] 13/15 VUs  1m42.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m48.0s
+autocomplete              • [   0% ] waiting    3m18.0s
+get_by_id                 • [   0% ] waiting    05m48.0s
+get_categories            • [   0% ] waiting    08m18.0s
+
+running (04m13.0s), 14/16 VUs, 48 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  69% ] 14/15 VUs  1m43.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m47.0s
+autocomplete              • [   0% ] waiting    3m17.0s
+get_by_id                 • [   0% ] waiting    05m47.0s
+get_categories            • [   0% ] waiting    08m17.0s
+
+running (04m14.0s), 14/16 VUs, 49 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  69% ] 14/15 VUs  1m44.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m46.0s
+autocomplete              • [   0% ] waiting    3m16.0s
+get_by_id                 • [   0% ] waiting    05m46.0s
+get_categories            • [   0% ] waiting    08m16.0s
+
+running (04m15.0s), 14/16 VUs, 49 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  70% ] 14/15 VUs  1m45.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m45.0s
+autocomplete              • [   0% ] waiting    3m15.0s
+get_by_id                 • [   0% ] waiting    05m45.0s
+get_categories            • [   0% ] waiting    08m15.0s
+time="2026-03-12T14:24:30Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?categoryName=Furniture&minPrice=62&maxPrice=4243&sortBy=price&sortDir=asc&size=20&page=5\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (04m16.0s), 15/16 VUs, 49 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  71% ] 15/15 VUs  1m46.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m44.0s
+autocomplete              • [   0% ] waiting    3m14.0s
+get_by_id                 • [   0% ] waiting    05m44.0s
+get_categories            • [   0% ] waiting    08m14.0s
+time="2026-03-12T14:24:31Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?categoryName=Sports%20%26%20Outdoors&minPrice=436&maxPrice=4513&sortBy=price&sortDir=desc&size=20&page=7\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (04m17.0s), 15/16 VUs, 50 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  71% ] 15/15 VUs  1m47.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m43.0s
+autocomplete              • [   0% ] waiting    3m13.0s
+get_by_id                 • [   0% ] waiting    05m43.0s
+get_categories            • [   0% ] waiting    08m13.0s
+
+running (04m18.0s), 15/16 VUs, 52 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  72% ] 15/15 VUs  1m48.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m42.0s
+autocomplete              • [   0% ] waiting    3m12.0s
+get_by_id                 • [   0% ] waiting    05m42.0s
+get_categories            • [   0% ] waiting    08m12.0s
+
+running (04m19.0s), 15/16 VUs, 52 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  73% ] 15/15 VUs  1m49.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m41.0s
+autocomplete              • [   0% ] waiting    3m11.0s
+get_by_id                 • [   0% ] waiting    05m41.0s
+get_categories            • [   0% ] waiting    08m11.0s
+
+running (04m20.0s), 15/16 VUs, 52 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  73% ] 15/15 VUs  1m50.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m40.0s
+autocomplete              • [   0% ] waiting    3m10.0s
+get_by_id                 • [   0% ] waiting    05m40.0s
+get_categories            • [   0% ] waiting    08m10.0s
+
+running (04m21.0s), 15/16 VUs, 53 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  74% ] 15/15 VUs  1m51.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m39.0s
+autocomplete              • [   0% ] waiting    3m09.0s
+get_by_id                 • [   0% ] waiting    05m39.0s
+get_categories            • [   0% ] waiting    08m09.0s
+
+running (04m22.0s), 15/16 VUs, 53 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  75% ] 15/15 VUs  1m52.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m38.0s
+autocomplete              • [   0% ] waiting    3m08.0s
+get_by_id                 • [   0% ] waiting    05m38.0s
+get_categories            • [   0% ] waiting    08m08.0s
+
+running (04m23.0s), 15/16 VUs, 53 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  75% ] 15/15 VUs  1m53.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m37.0s
+autocomplete              • [   0% ] waiting    3m07.0s
+get_by_id                 • [   0% ] waiting    05m37.0s
+get_categories            • [   0% ] waiting    08m07.0s
+
+running (04m24.0s), 15/16 VUs, 54 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  76% ] 15/15 VUs  1m54.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m36.0s
+autocomplete              • [   0% ] waiting    3m06.0s
+get_by_id                 • [   0% ] waiting    05m36.0s
+get_categories            • [   0% ] waiting    08m06.0s
+
+running (04m25.0s), 15/16 VUs, 54 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  77% ] 15/15 VUs  1m55.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m35.0s
+autocomplete              • [   0% ] waiting    3m05.0s
+get_by_id                 • [   0% ] waiting    05m35.0s
+get_categories            • [   0% ] waiting    08m05.0s
+
+running (04m26.0s), 15/16 VUs, 55 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  77% ] 15/15 VUs  1m56.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m34.0s
+autocomplete              • [   0% ] waiting    3m04.0s
+get_by_id                 • [   0% ] waiting    05m34.0s
+get_categories            • [   0% ] waiting    08m04.0s
+
+running (04m27.0s), 15/16 VUs, 56 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  78% ] 15/15 VUs  1m57.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m33.0s
+autocomplete              • [   0% ] waiting    3m03.0s
+get_by_id                 • [   0% ] waiting    05m33.0s
+get_categories            • [   0% ] waiting    08m03.0s
+
+running (04m28.0s), 15/16 VUs, 56 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  79% ] 15/15 VUs  1m58.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m32.0s
+autocomplete              • [   0% ] waiting    3m02.0s
+get_by_id                 • [   0% ] waiting    05m32.0s
+get_categories            • [   0% ] waiting    08m02.0s
+
+running (04m29.0s), 15/16 VUs, 56 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  79% ] 15/15 VUs  1m59.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m31.0s
+autocomplete              • [   0% ] waiting    3m01.0s
+get_by_id                 • [   0% ] waiting    05m31.0s
+get_categories            • [   0% ] waiting    08m01.0s
+
+running (04m30.0s), 15/16 VUs, 56 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  80% ] 15/15 VUs  2m00.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m30.0s
+autocomplete              • [   0% ] waiting    3m00.0s
+get_by_id                 • [   0% ] waiting    05m30.0s
+get_categories            • [   0% ] waiting    08m00.0s
+
+running (04m31.0s), 15/16 VUs, 57 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  81% ] 15/15 VUs  2m01.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m29.0s
+autocomplete              • [   0% ] waiting    2m59.0s
+get_by_id                 • [   0% ] waiting    05m29.0s
+get_categories            • [   0% ] waiting    07m59.0s
+
+running (04m32.0s), 15/16 VUs, 58 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  81% ] 15/15 VUs  2m02.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m28.0s
+autocomplete              • [   0% ] waiting    2m58.0s
+get_by_id                 • [   0% ] waiting    05m28.0s
+get_categories            • [   0% ] waiting    07m58.0s
+
+running (04m33.0s), 15/16 VUs, 58 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  82% ] 15/15 VUs  2m03.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m27.0s
+autocomplete              • [   0% ] waiting    2m57.0s
+get_by_id                 • [   0% ] waiting    05m27.0s
+get_categories            • [   0% ] waiting    07m57.0s
+
+running (04m34.0s), 15/16 VUs, 59 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  83% ] 15/15 VUs  2m04.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m26.0s
+autocomplete              • [   0% ] waiting    2m56.0s
+get_by_id                 • [   0% ] waiting    05m26.0s
+get_categories            • [   0% ] waiting    07m56.0s
+
+running (04m35.0s), 15/16 VUs, 61 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  83% ] 15/15 VUs  2m05.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m25.0s
+autocomplete              • [   0% ] waiting    2m55.0s
+get_by_id                 • [   0% ] waiting    05m25.0s
+get_categories            • [   0% ] waiting    07m55.0s
+
+running (04m36.0s), 15/16 VUs, 61 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  84% ] 15/15 VUs  2m06.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m24.0s
+autocomplete              • [   0% ] waiting    2m54.0s
+get_by_id                 • [   0% ] waiting    05m24.0s
+get_categories            • [   0% ] waiting    07m54.0s
+
+running (04m37.0s), 15/16 VUs, 61 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  85% ] 15/15 VUs  2m07.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m23.0s
+autocomplete              • [   0% ] waiting    2m53.0s
+get_by_id                 • [   0% ] waiting    05m23.0s
+get_categories            • [   0% ] waiting    07m53.0s
+
+running (04m38.0s), 15/16 VUs, 61 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  85% ] 15/15 VUs  2m08.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m22.0s
+autocomplete              • [   0% ] waiting    2m52.0s
+get_by_id                 • [   0% ] waiting    05m22.0s
+get_categories            • [   0% ] waiting    07m52.0s
+
+running (04m39.0s), 15/16 VUs, 62 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  86% ] 15/15 VUs  2m09.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m21.0s
+autocomplete              • [   0% ] waiting    2m51.0s
+get_by_id                 • [   0% ] waiting    05m21.0s
+get_categories            • [   0% ] waiting    07m51.0s
+
+running (04m40.0s), 15/16 VUs, 62 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  87% ] 15/15 VUs  2m10.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m20.0s
+autocomplete              • [   0% ] waiting    2m50.0s
+get_by_id                 • [   0% ] waiting    05m20.0s
+get_categories            • [   0% ] waiting    07m50.0s
+
+running (04m41.0s), 15/16 VUs, 62 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  87% ] 15/15 VUs  2m11.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m19.0s
+autocomplete              • [   0% ] waiting    2m49.0s
+get_by_id                 • [   0% ] waiting    05m19.0s
+get_categories            • [   0% ] waiting    07m49.0s
+
+running (04m42.0s), 15/16 VUs, 63 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  88% ] 15/15 VUs  2m12.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m18.0s
+autocomplete              • [   0% ] waiting    2m48.0s
+get_by_id                 • [   0% ] waiting    05m18.0s
+get_categories            • [   0% ] waiting    07m48.0s
+
+running (04m43.0s), 15/16 VUs, 63 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  89% ] 15/15 VUs  2m13.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m17.0s
+autocomplete              • [   0% ] waiting    2m47.0s
+get_by_id                 • [   0% ] waiting    05m17.0s
+get_categories            • [   0% ] waiting    07m47.0s
+
+running (04m44.0s), 15/16 VUs, 64 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  89% ] 15/15 VUs  2m14.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m16.0s
+autocomplete              • [   0% ] waiting    2m46.0s
+get_by_id                 • [   0% ] waiting    05m16.0s
+get_categories            • [   0% ] waiting    07m46.0s
+
+running (04m45.0s), 15/16 VUs, 65 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  90% ] 15/15 VUs  2m15.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m15.0s
+autocomplete              • [   0% ] waiting    2m45.0s
+get_by_id                 • [   0% ] waiting    05m15.0s
+get_categories            • [   0% ] waiting    07m45.0s
+
+running (04m46.0s), 15/16 VUs, 65 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  91% ] 15/15 VUs  2m16.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m14.0s
+autocomplete              • [   0% ] waiting    2m44.0s
+get_by_id                 • [   0% ] waiting    05m14.0s
+get_categories            • [   0% ] waiting    07m44.0s
+
+running (04m47.0s), 15/16 VUs, 65 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  91% ] 15/15 VUs  2m17.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m13.0s
+autocomplete              • [   0% ] waiting    2m43.0s
+get_by_id                 • [   0% ] waiting    05m13.0s
+get_categories            • [   0% ] waiting    07m43.0s
+
+running (04m48.0s), 15/16 VUs, 65 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  92% ] 15/15 VUs  2m18.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m12.0s
+autocomplete              • [   0% ] waiting    2m42.0s
+get_by_id                 • [   0% ] waiting    05m12.0s
+get_categories            • [   0% ] waiting    07m42.0s
+
+running (04m49.0s), 14/16 VUs, 67 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  93% ] 14/15 VUs  2m19.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m11.0s
+autocomplete              • [   0% ] waiting    2m41.0s
+get_by_id                 • [   0% ] waiting    05m11.0s
+get_categories            • [   0% ] waiting    07m41.0s
+
+running (04m50.0s), 14/16 VUs, 67 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  93% ] 14/15 VUs  2m20.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m10.0s
+autocomplete              • [   0% ] waiting    2m40.0s
+get_by_id                 • [   0% ] waiting    05m10.0s
+get_categories            • [   0% ] waiting    07m40.0s
+
+running (04m51.0s), 14/16 VUs, 67 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  94% ] 14/15 VUs  2m21.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m09.0s
+autocomplete              • [   0% ] waiting    2m39.0s
+get_by_id                 • [   0% ] waiting    05m09.0s
+get_categories            • [   0% ] waiting    07m39.0s
+
+running (04m52.0s), 14/16 VUs, 68 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  95% ] 14/15 VUs  2m22.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m08.0s
+autocomplete              • [   0% ] waiting    2m38.0s
+get_by_id                 • [   0% ] waiting    05m08.0s
+get_categories            • [   0% ] waiting    07m38.0s
+
+running (04m53.0s), 14/16 VUs, 68 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  95% ] 14/15 VUs  2m23.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m07.0s
+autocomplete              • [   0% ] waiting    2m37.0s
+get_by_id                 • [   0% ] waiting    05m07.0s
+get_categories            • [   0% ] waiting    07m37.0s
+
+running (04m54.0s), 14/16 VUs, 68 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  96% ] 14/15 VUs  2m24.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m06.0s
+autocomplete              • [   0% ] waiting    2m36.0s
+get_by_id                 • [   0% ] waiting    05m06.0s
+get_categories            • [   0% ] waiting    07m36.0s
+
+running (04m55.0s), 13/16 VUs, 69 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  97% ] 13/15 VUs  2m25.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m05.0s
+autocomplete              • [   0% ] waiting    2m35.0s
+get_by_id                 • [   0% ] waiting    05m05.0s
+get_categories            • [   0% ] waiting    07m35.0s
+
+running (04m56.0s), 13/16 VUs, 69 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  97% ] 13/15 VUs  2m26.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m04.0s
+autocomplete              • [   0% ] waiting    2m34.0s
+get_by_id                 • [   0% ] waiting    05m04.0s
+get_categories            • [   0% ] waiting    07m34.0s
+
+running (04m57.0s), 12/16 VUs, 70 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  98% ] 12/15 VUs  2m27.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m03.0s
+autocomplete              • [   0% ] waiting    2m33.0s
+get_by_id                 • [   0% ] waiting    05m03.0s
+get_categories            • [   0% ] waiting    07m33.0s
+
+running (04m58.0s), 12/16 VUs, 71 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  99% ] 12/15 VUs  2m28.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m02.0s
+autocomplete              • [   0% ] waiting    2m32.0s
+get_by_id                 • [   0% ] waiting    05m02.0s
+get_categories            • [   0% ] waiting    07m32.0s
+
+running (04m59.0s), 12/16 VUs, 71 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [  99% ] 12/15 VUs  2m29.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m01.0s
+autocomplete              • [   0% ] waiting    2m31.0s
+get_by_id                 • [   0% ] waiting    05m01.0s
+get_categories            • [   0% ] waiting    07m31.0s
+
+running (05m00.0s), 12/16 VUs, 71 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated   [ 100% ] 12/15 VUs  2m30.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m00.0s
+autocomplete              • [   0% ] waiting    2m30.0s
+get_by_id                 • [   0% ] waiting    05m00.0s
+get_categories            • [   0% ] waiting    07m30.0s
+
+running (05m01.0s), 13/16 VUs, 71 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ↓ [ 100% ] 12/15 VUs  2m30s
+multi_field_search          [   1% ] 01/15 VUs  0m01.0s/2m30.0s
+autocomplete              • [   0% ] waiting    2m29.0s
+get_by_id                 • [   0% ] waiting    04m59.0s
+get_categories            • [   0% ] waiting    07m29.0s
+
+running (05m02.0s), 12/16 VUs, 72 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ↓ [ 100% ] 12/15 VUs  2m30s
+multi_field_search          [   1% ] 01/15 VUs  0m02.0s/2m30.0s
+autocomplete              • [   0% ] waiting    2m28.0s
+get_by_id                 • [   0% ] waiting    04m58.0s
+get_categories            • [   0% ] waiting    07m28.0s
+
+running (05m03.0s), 11/16 VUs, 73 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ↓ [ 100% ] 12/15 VUs  2m30s
+multi_field_search          [   2% ] 01/15 VUs  0m03.0s/2m30.0s
+autocomplete              • [   0% ] waiting    2m27.0s
+get_by_id                 • [   0% ] waiting    04m57.0s
+get_categories            • [   0% ] waiting    07m27.0s
+
+running (05m04.0s), 11/16 VUs, 73 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ↓ [ 100% ] 12/15 VUs  2m30s
+multi_field_search          [   3% ] 01/15 VUs  0m04.0s/2m30.0s
+autocomplete              • [   0% ] waiting    2m26.0s
+get_by_id                 • [   0% ] waiting    04m56.0s
+get_categories            • [   0% ] waiting    07m26.0s
+
+running (05m05.0s), 10/16 VUs, 74 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ↓ [ 100% ] 12/15 VUs  2m30s
+multi_field_search          [   3% ] 01/15 VUs  0m05.0s/2m30.0s
+autocomplete              • [   0% ] waiting    2m25.0s
+get_by_id                 • [   0% ] waiting    04m55.0s
+get_categories            • [   0% ] waiting    07m25.0s
+
+running (05m06.0s), 08/16 VUs, 76 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ↓ [ 100% ] 12/15 VUs  2m30s
+multi_field_search          [   4% ] 01/15 VUs  0m06.0s/2m30.0s
+autocomplete              • [   0% ] waiting    2m24.0s
+get_by_id                 • [   0% ] waiting    04m54.0s
+get_categories            • [   0% ] waiting    07m24.0s
+
+running (05m07.0s), 08/16 VUs, 76 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ↓ [ 100% ] 12/15 VUs  2m30s
+multi_field_search          [   5% ] 01/15 VUs  0m07.0s/2m30.0s
+autocomplete              • [   0% ] waiting    2m23.0s
+get_by_id                 • [   0% ] waiting    04m53.0s
+get_categories            • [   0% ] waiting    07m23.0s
+
+running (05m08.0s), 08/16 VUs, 76 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ↓ [ 100% ] 12/15 VUs  2m30s
+multi_field_search          [   5% ] 01/15 VUs  0m08.0s/2m30.0s
+autocomplete              • [   0% ] waiting    2m22.0s
+get_by_id                 • [   0% ] waiting    04m52.0s
+get_categories            • [   0% ] waiting    07m22.0s
+
+running (05m09.0s), 08/16 VUs, 76 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ↓ [ 100% ] 12/15 VUs  2m30s
+multi_field_search          [   6% ] 01/15 VUs  0m09.0s/2m30.0s
+autocomplete              • [   0% ] waiting    2m21.0s
+get_by_id                 • [   0% ] waiting    04m51.0s
+get_categories            • [   0% ] waiting    07m21.0s
+
+running (05m10.0s), 07/16 VUs, 77 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ↓ [ 100% ] 12/15 VUs  2m30s
+multi_field_search          [   7% ] 01/15 VUs  0m10.0s/2m30.0s
+autocomplete              • [   0% ] waiting    2m20.0s
+get_by_id                 • [   0% ] waiting    04m50.0s
+get_categories            • [   0% ] waiting    07m20.0s
+
+running (05m11.0s), 07/16 VUs, 77 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ↓ [ 100% ] 12/15 VUs  2m30s
+multi_field_search          [   7% ] 01/15 VUs  0m11.0s/2m30.0s
+autocomplete              • [   0% ] waiting    2m19.0s
+get_by_id                 • [   0% ] waiting    04m49.0s
+get_categories            • [   0% ] waiting    07m19.0s
+
+running (05m12.0s), 07/16 VUs, 77 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ↓ [ 100% ] 12/15 VUs  2m30s
+multi_field_search          [   8% ] 01/15 VUs  0m12.0s/2m30.0s
+autocomplete              • [   0% ] waiting    2m18.0s
+get_by_id                 • [   0% ] waiting    04m48.0s
+get_categories            • [   0% ] waiting    07m18.0s
+
+running (05m13.0s), 06/16 VUs, 78 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ↓ [ 100% ] 12/15 VUs  2m30s
+multi_field_search          [   9% ] 01/15 VUs  0m13.0s/2m30.0s
+autocomplete              • [   0% ] waiting    2m17.0s
+get_by_id                 • [   0% ] waiting    04m47.0s
+get_categories            • [   0% ] waiting    07m17.0s
+
+running (05m14.0s), 06/16 VUs, 78 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ↓ [ 100% ] 12/15 VUs  2m30s
+multi_field_search          [   9% ] 01/15 VUs  0m14.0s/2m30.0s
+autocomplete              • [   0% ] waiting    2m16.0s
+get_by_id                 • [   0% ] waiting    04m46.0s
+get_categories            • [   0% ] waiting    07m16.0s
+
+running (05m15.0s), 05/16 VUs, 79 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ↓ [ 100% ] 12/15 VUs  2m30s
+multi_field_search          [  10% ] 01/15 VUs  0m15.0s/2m30.0s
+autocomplete              • [   0% ] waiting    2m15.0s
+get_by_id                 • [   0% ] waiting    04m45.0s
+get_categories            • [   0% ] waiting    07m15.0s
+
+running (05m16.0s), 04/16 VUs, 80 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ↓ [ 100% ] 12/15 VUs  2m30s
+multi_field_search          [  11% ] 01/15 VUs  0m16.0s/2m30.0s
+autocomplete              • [   0% ] waiting    2m14.0s
+get_by_id                 • [   0% ] waiting    04m44.0s
+get_categories            • [   0% ] waiting    07m14.0s
+
+running (05m17.0s), 04/16 VUs, 80 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ↓ [ 100% ] 12/15 VUs  2m30s
+multi_field_search          [  11% ] 01/15 VUs  0m17.0s/2m30.0s
+autocomplete              • [   0% ] waiting    2m13.0s
+get_by_id                 • [   0% ] waiting    04m43.0s
+get_categories            • [   0% ] waiting    07m13.0s
+
+running (05m18.0s), 04/16 VUs, 80 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ↓ [ 100% ] 12/15 VUs  2m30s
+multi_field_search          [  12% ] 01/15 VUs  0m18.0s/2m30.0s
+autocomplete              • [   0% ] waiting    2m12.0s
+get_by_id                 • [   0% ] waiting    04m42.0s
+get_categories            • [   0% ] waiting    07m12.0s
+
+running (05m19.0s), 04/16 VUs, 80 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ↓ [ 100% ] 12/15 VUs  2m30s
+multi_field_search          [  13% ] 01/15 VUs  0m19.0s/2m30.0s
+autocomplete              • [   0% ] waiting    2m11.0s
+get_by_id                 • [   0% ] waiting    04m41.0s
+get_categories            • [   0% ] waiting    07m11.0s
+
+running (05m20.0s), 03/16 VUs, 81 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ↓ [ 100% ] 12/15 VUs  2m30s
+multi_field_search          [  13% ] 01/15 VUs  0m20.0s/2m30.0s
+autocomplete              • [   0% ] waiting    2m10.0s
+get_by_id                 • [   0% ] waiting    04m40.0s
+get_categories            • [   0% ] waiting    07m10.0s
+
+running (05m21.0s), 03/16 VUs, 81 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ↓ [ 100% ] 12/15 VUs  2m30s
+multi_field_search          [  14% ] 01/15 VUs  0m21.0s/2m30.0s
+autocomplete              • [   0% ] waiting    2m09.0s
+get_by_id                 • [   0% ] waiting    04m39.0s
+get_categories            • [   0% ] waiting    07m09.0s
+
+running (05m22.0s), 03/16 VUs, 81 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ↓ [ 100% ] 12/15 VUs  2m30s
+multi_field_search          [  15% ] 01/15 VUs  0m22.0s/2m30.0s
+autocomplete              • [   0% ] waiting    2m08.0s
+get_by_id                 • [   0% ] waiting    04m38.0s
+get_categories            • [   0% ] waiting    07m08.0s
+
+running (05m23.0s), 03/16 VUs, 82 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ↓ [ 100% ] 12/15 VUs  2m30s
+multi_field_search          [  15% ] 02/15 VUs  0m23.0s/2m30.0s
+autocomplete              • [   0% ] waiting    2m07.0s
+get_by_id                 • [   0% ] waiting    04m37.0s
+get_categories            • [   0% ] waiting    07m07.0s
+
+running (05m24.0s), 03/16 VUs, 82 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ↓ [ 100% ] 12/15 VUs  2m30s
+multi_field_search          [  16% ] 02/15 VUs  0m24.0s/2m30.0s
+autocomplete              • [   0% ] waiting    2m06.0s
+get_by_id                 • [   0% ] waiting    04m36.0s
+get_categories            • [   0% ] waiting    07m06.0s
+
+running (05m25.0s), 03/16 VUs, 82 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ↓ [ 100% ] 12/15 VUs  2m30s
+multi_field_search          [  17% ] 02/15 VUs  0m25.0s/2m30.0s
+autocomplete              • [   0% ] waiting    2m05.0s
+get_by_id                 • [   0% ] waiting    04m35.0s
+get_categories            • [   0% ] waiting    07m05.0s
+
+running (05m26.0s), 03/16 VUs, 82 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ↓ [ 100% ] 12/15 VUs  2m30s
+multi_field_search          [  17% ] 02/15 VUs  0m26.0s/2m30.0s
+autocomplete              • [   0% ] waiting    2m04.0s
+get_by_id                 • [   0% ] waiting    04m34.0s
+get_categories            • [   0% ] waiting    07m04.0s
+
+running (05m27.0s), 03/16 VUs, 82 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ↓ [ 100% ] 12/15 VUs  2m30s
+multi_field_search          [  18% ] 02/15 VUs  0m27.0s/2m30.0s
+autocomplete              • [   0% ] waiting    2m03.0s
+get_by_id                 • [   0% ] waiting    04m33.0s
+get_categories            • [   0% ] waiting    07m03.0s
+
+running (05m28.0s), 03/16 VUs, 82 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ↓ [ 100% ] 12/15 VUs  2m30s
+multi_field_search          [  19% ] 02/15 VUs  0m28.0s/2m30.0s
+autocomplete              • [   0% ] waiting    2m02.0s
+get_by_id                 • [   0% ] waiting    04m32.0s
+get_categories            • [   0% ] waiting    07m02.0s
+
+running (05m29.0s), 02/16 VUs, 83 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  19% ] 02/15 VUs  0m29.0s/2m30.0s
+autocomplete              • [   0% ] waiting    2m01.0s
+get_by_id                 • [   0% ] waiting    04m31.0s
+get_categories            • [   0% ] waiting    07m01.0s
+
+running (05m30.0s), 02/16 VUs, 83 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  20% ] 02/15 VUs  0m30.0s/2m30.0s
+autocomplete              • [   0% ] waiting    2m00.0s
+get_by_id                 • [   0% ] waiting    04m30.0s
+get_categories            • [   0% ] waiting    07m00.0s
+
+running (05m31.0s), 03/16 VUs, 83 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  21% ] 03/15 VUs  0m31.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m59.0s
+get_by_id                 • [   0% ] waiting    04m29.0s
+get_categories            • [   0% ] waiting    06m59.0s
+
+running (05m32.0s), 03/16 VUs, 84 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  21% ] 03/15 VUs  0m32.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m58.0s
+get_by_id                 • [   0% ] waiting    04m28.0s
+get_categories            • [   0% ] waiting    06m58.0s
+
+running (05m33.0s), 03/16 VUs, 84 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  22% ] 03/15 VUs  0m33.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m57.0s
+get_by_id                 • [   0% ] waiting    04m27.0s
+get_categories            • [   0% ] waiting    06m57.0s
+
+running (05m34.0s), 03/16 VUs, 84 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  23% ] 03/15 VUs  0m34.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m56.0s
+get_by_id                 • [   0% ] waiting    04m26.0s
+get_categories            • [   0% ] waiting    06m56.0s
+
+running (05m35.0s), 03/16 VUs, 84 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  23% ] 03/15 VUs  0m35.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m55.0s
+get_by_id                 • [   0% ] waiting    04m25.0s
+get_categories            • [   0% ] waiting    06m55.0s
+
+running (05m36.0s), 03/16 VUs, 84 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  24% ] 03/15 VUs  0m36.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m54.0s
+get_by_id                 • [   0% ] waiting    04m24.0s
+get_categories            • [   0% ] waiting    06m54.0s
+
+running (05m37.0s), 03/16 VUs, 84 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  25% ] 03/15 VUs  0m37.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m53.0s
+get_by_id                 • [   0% ] waiting    04m23.0s
+get_categories            • [   0% ] waiting    06m53.0s
+
+running (05m38.0s), 04/16 VUs, 84 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  25% ] 04/15 VUs  0m38.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m52.0s
+get_by_id                 • [   0% ] waiting    04m22.0s
+get_categories            • [   0% ] waiting    06m52.0s
+
+running (05m39.0s), 04/16 VUs, 84 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  26% ] 04/15 VUs  0m39.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m51.0s
+get_by_id                 • [   0% ] waiting    04m21.0s
+get_categories            • [   0% ] waiting    06m51.0s
+
+running (05m40.0s), 04/16 VUs, 84 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  27% ] 04/15 VUs  0m40.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m50.0s
+get_by_id                 • [   0% ] waiting    04m20.0s
+get_categories            • [   0% ] waiting    06m50.0s
+
+running (05m41.0s), 04/16 VUs, 84 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  27% ] 04/15 VUs  0m41.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m49.0s
+get_by_id                 • [   0% ] waiting    04m19.0s
+get_categories            • [   0% ] waiting    06m49.0s
+
+running (05m42.0s), 04/16 VUs, 84 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  28% ] 04/15 VUs  0m42.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m48.0s
+get_by_id                 • [   0% ] waiting    04m18.0s
+get_categories            • [   0% ] waiting    06m48.0s
+
+running (05m43.0s), 04/16 VUs, 84 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  29% ] 04/15 VUs  0m43.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m47.0s
+get_by_id                 • [   0% ] waiting    04m17.0s
+get_categories            • [   0% ] waiting    06m47.0s
+
+running (05m44.0s), 04/16 VUs, 84 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  29% ] 04/15 VUs  0m44.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m46.0s
+get_by_id                 • [   0% ] waiting    04m16.0s
+get_categories            • [   0% ] waiting    06m46.0s
+
+running (05m45.0s), 04/16 VUs, 84 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  30% ] 04/15 VUs  0m45.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m45.0s
+get_by_id                 • [   0% ] waiting    04m15.0s
+get_categories            • [   0% ] waiting    06m45.0s
+
+running (05m46.0s), 05/16 VUs, 84 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  31% ] 05/15 VUs  0m46.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m44.0s
+get_by_id                 • [   0% ] waiting    04m14.0s
+get_categories            • [   0% ] waiting    06m44.0s
+
+running (05m47.0s), 05/16 VUs, 84 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  31% ] 05/15 VUs  0m47.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m43.0s
+get_by_id                 • [   0% ] waiting    04m13.0s
+get_categories            • [   0% ] waiting    06m43.0s
+
+running (05m48.0s), 05/16 VUs, 84 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  32% ] 05/15 VUs  0m48.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m42.0s
+get_by_id                 • [   0% ] waiting    04m12.0s
+get_categories            • [   0% ] waiting    06m42.0s
+
+running (05m49.0s), 05/16 VUs, 84 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  33% ] 05/15 VUs  0m49.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m41.0s
+get_by_id                 • [   0% ] waiting    04m11.0s
+get_categories            • [   0% ] waiting    06m41.0s
+
+running (05m50.0s), 05/16 VUs, 84 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  33% ] 05/15 VUs  0m50.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m40.0s
+get_by_id                 • [   0% ] waiting    04m10.0s
+get_categories            • [   0% ] waiting    06m40.0s
+
+running (05m51.0s), 05/16 VUs, 84 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  34% ] 05/15 VUs  0m51.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m39.0s
+get_by_id                 • [   0% ] waiting    04m09.0s
+get_categories            • [   0% ] waiting    06m39.0s
+
+running (05m52.0s), 05/16 VUs, 84 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  35% ] 05/15 VUs  0m52.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m38.0s
+get_by_id                 • [   0% ] waiting    04m08.0s
+get_categories            • [   0% ] waiting    06m38.0s
+
+running (05m53.0s), 05/16 VUs, 84 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  35% ] 05/15 VUs  0m53.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m37.0s
+get_by_id                 • [   0% ] waiting    04m07.0s
+get_categories            • [   0% ] waiting    06m37.0s
+
+running (05m54.0s), 05/16 VUs, 85 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  36% ] 05/15 VUs  0m54.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m36.0s
+get_by_id                 • [   0% ] waiting    04m06.0s
+get_categories            • [   0% ] waiting    06m36.0s
+
+running (05m55.0s), 05/16 VUs, 85 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  37% ] 05/15 VUs  0m55.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m35.0s
+get_by_id                 • [   0% ] waiting    04m05.0s
+get_categories            • [   0% ] waiting    06m35.0s
+
+running (05m56.0s), 05/16 VUs, 85 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  37% ] 05/15 VUs  0m56.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m34.0s
+get_by_id                 • [   0% ] waiting    04m04.0s
+get_categories            • [   0% ] waiting    06m34.0s
+
+running (05m57.0s), 05/16 VUs, 85 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  38% ] 05/15 VUs  0m57.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m33.0s
+get_by_id                 • [   0% ] waiting    04m03.0s
+get_categories            • [   0% ] waiting    06m33.0s
+
+running (05m58.0s), 05/16 VUs, 85 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  39% ] 05/15 VUs  0m58.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m32.0s
+get_by_id                 • [   0% ] waiting    04m02.0s
+get_categories            • [   0% ] waiting    06m32.0s
+
+running (05m59.0s), 05/16 VUs, 85 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  39% ] 05/15 VUs  0m59.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m31.0s
+get_by_id                 • [   0% ] waiting    04m01.0s
+get_categories            • [   0% ] waiting    06m31.0s
+
+running (06m00.0s), 05/16 VUs, 85 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  40% ] 05/15 VUs  1m00.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m30.0s
+get_by_id                 • [   0% ] waiting    04m00.0s
+get_categories            • [   0% ] waiting    06m30.0s
+
+running (06m01.0s), 05/16 VUs, 85 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  41% ] 05/15 VUs  1m01.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m29.0s
+get_by_id                 • [   0% ] waiting    03m59.0s
+get_categories            • [   0% ] waiting    06m29.0s
+
+running (06m02.0s), 05/16 VUs, 86 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  41% ] 05/15 VUs  1m02.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m28.0s
+get_by_id                 • [   0% ] waiting    03m58.0s
+get_categories            • [   0% ] waiting    06m28.0s
+
+running (06m03.0s), 05/16 VUs, 87 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  42% ] 05/15 VUs  1m03.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m27.0s
+get_by_id                 • [   0% ] waiting    03m57.0s
+get_categories            • [   0% ] waiting    06m27.0s
+
+running (06m04.0s), 05/16 VUs, 87 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  43% ] 05/15 VUs  1m04.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m26.0s
+get_by_id                 • [   0% ] waiting    03m56.0s
+get_categories            • [   0% ] waiting    06m26.0s
+
+running (06m05.0s), 05/16 VUs, 87 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  43% ] 05/15 VUs  1m05.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m25.0s
+get_by_id                 • [   0% ] waiting    03m55.0s
+get_categories            • [   0% ] waiting    06m25.0s
+
+running (06m06.0s), 05/16 VUs, 87 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  44% ] 05/15 VUs  1m06.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m24.0s
+get_by_id                 • [   0% ] waiting    03m54.0s
+get_categories            • [   0% ] waiting    06m24.0s
+
+running (06m07.0s), 05/16 VUs, 87 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  45% ] 05/15 VUs  1m07.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m23.0s
+get_by_id                 • [   0% ] waiting    03m53.0s
+get_categories            • [   0% ] waiting    06m23.0s
+
+running (06m08.0s), 05/16 VUs, 87 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  45% ] 05/15 VUs  1m08.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m22.0s
+get_by_id                 • [   0% ] waiting    03m52.0s
+get_categories            • [   0% ] waiting    06m22.0s
+
+running (06m09.0s), 05/16 VUs, 88 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  46% ] 05/15 VUs  1m09.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m21.0s
+get_by_id                 • [   0% ] waiting    03m51.0s
+get_categories            • [   0% ] waiting    06m21.0s
+
+running (06m10.0s), 05/16 VUs, 88 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  47% ] 05/15 VUs  1m10.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m20.0s
+get_by_id                 • [   0% ] waiting    03m50.0s
+get_categories            • [   0% ] waiting    06m20.0s
+
+running (06m11.0s), 05/16 VUs, 88 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  47% ] 05/15 VUs  1m11.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m19.0s
+get_by_id                 • [   0% ] waiting    03m49.0s
+get_categories            • [   0% ] waiting    06m19.0s
+
+running (06m12.0s), 05/16 VUs, 88 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  48% ] 05/15 VUs  1m12.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m18.0s
+get_by_id                 • [   0% ] waiting    03m48.0s
+get_categories            • [   0% ] waiting    06m18.0s
+
+running (06m13.0s), 05/16 VUs, 88 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  49% ] 05/15 VUs  1m13.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m17.0s
+get_by_id                 • [   0% ] waiting    03m47.0s
+get_categories            • [   0% ] waiting    06m17.0s
+
+running (06m14.0s), 05/16 VUs, 88 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  49% ] 05/15 VUs  1m14.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m16.0s
+get_by_id                 • [   0% ] waiting    03m46.0s
+get_categories            • [   0% ] waiting    06m16.0s
+
+running (06m15.0s), 05/16 VUs, 88 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  50% ] 05/15 VUs  1m15.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m15.0s
+get_by_id                 • [   0% ] waiting    03m45.0s
+get_categories            • [   0% ] waiting    06m15.0s
+
+running (06m16.0s), 05/16 VUs, 88 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  51% ] 05/15 VUs  1m16.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m14.0s
+get_by_id                 • [   0% ] waiting    03m44.0s
+get_categories            • [   0% ] waiting    06m14.0s
+
+running (06m17.0s), 05/16 VUs, 89 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  51% ] 05/15 VUs  1m17.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m13.0s
+get_by_id                 • [   0% ] waiting    03m43.0s
+get_categories            • [   0% ] waiting    06m13.0s
+
+running (06m18.0s), 05/16 VUs, 89 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  52% ] 05/15 VUs  1m18.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m12.0s
+get_by_id                 • [   0% ] waiting    03m42.0s
+get_categories            • [   0% ] waiting    06m12.0s
+
+running (06m19.0s), 06/16 VUs, 89 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  53% ] 06/15 VUs  1m19.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m11.0s
+get_by_id                 • [   0% ] waiting    03m41.0s
+get_categories            • [   0% ] waiting    06m11.0s
+
+running (06m20.0s), 06/16 VUs, 89 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  53% ] 06/15 VUs  1m20.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m10.0s
+get_by_id                 • [   0% ] waiting    03m40.0s
+get_categories            • [   0% ] waiting    06m10.0s
+
+running (06m21.0s), 06/16 VUs, 89 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  54% ] 06/15 VUs  1m21.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m09.0s
+get_by_id                 • [   0% ] waiting    03m39.0s
+get_categories            • [   0% ] waiting    06m09.0s
+
+running (06m22.0s), 07/16 VUs, 89 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  55% ] 07/15 VUs  1m22.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m08.0s
+get_by_id                 • [   0% ] waiting    03m38.0s
+get_categories            • [   0% ] waiting    06m08.0s
+
+running (06m23.0s), 07/16 VUs, 89 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  55% ] 07/15 VUs  1m23.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m07.0s
+get_by_id                 • [   0% ] waiting    03m37.0s
+get_categories            • [   0% ] waiting    06m07.0s
+
+running (06m24.0s), 07/16 VUs, 89 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  56% ] 07/15 VUs  1m24.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m06.0s
+get_by_id                 • [   0% ] waiting    03m36.0s
+get_categories            • [   0% ] waiting    06m06.0s
+
+running (06m25.0s), 08/16 VUs, 90 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  57% ] 08/15 VUs  1m25.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m05.0s
+get_by_id                 • [   0% ] waiting    03m35.0s
+get_categories            • [   0% ] waiting    06m05.0s
+
+running (06m26.0s), 08/16 VUs, 90 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  57% ] 08/15 VUs  1m26.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m04.0s
+get_by_id                 • [   0% ] waiting    03m34.0s
+get_categories            • [   0% ] waiting    06m04.0s
+
+running (06m27.0s), 08/16 VUs, 90 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  58% ] 08/15 VUs  1m27.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m03.0s
+get_by_id                 • [   0% ] waiting    03m33.0s
+get_categories            • [   0% ] waiting    06m03.0s
+
+running (06m28.0s), 09/16 VUs, 90 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  59% ] 09/15 VUs  1m28.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m02.0s
+get_by_id                 • [   0% ] waiting    03m32.0s
+get_categories            • [   0% ] waiting    06m02.0s
+
+running (06m29.0s), 09/16 VUs, 90 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  59% ] 09/15 VUs  1m29.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m01.0s
+get_by_id                 • [   0% ] waiting    03m31.0s
+get_categories            • [   0% ] waiting    06m01.0s
+
+running (06m30.0s), 09/16 VUs, 90 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  60% ] 09/15 VUs  1m30.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m00.0s
+get_by_id                 • [   0% ] waiting    03m30.0s
+get_categories            • [   0% ] waiting    06m00.0s
+time="2026-03-12T14:26:45Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=cotton&categoryName=Sports%20%26%20Outdoors&size=20\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (06m31.0s), 10/16 VUs, 90 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  61% ] 10/15 VUs  1m31.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m59.0s
+get_by_id                 • [   0% ] waiting    03m29.0s
+get_categories            • [   0% ] waiting    05m59.0s
+time="2026-03-12T14:26:46Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=bamboo&categoryName=Jewelry&size=20\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (06m32.0s), 10/16 VUs, 91 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  61% ] 10/15 VUs  1m32.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m58.0s
+get_by_id                 • [   0% ] waiting    03m28.0s
+get_categories            • [   0% ] waiting    05m58.0s
+time="2026-03-12T14:26:47Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=denim&categoryName=Sports%20%26%20Outdoors&size=20\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (06m33.0s), 10/16 VUs, 93 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  62% ] 10/15 VUs  1m33.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m57.0s
+get_by_id                 • [   0% ] waiting    03m27.0s
+get_categories            • [   0% ] waiting    05m57.0s
+time="2026-03-12T14:26:48Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=silk&categoryName=Kitchen%20%26%20Dining&size=20\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (06m34.0s), 11/16 VUs, 95 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  63% ] 11/15 VUs  1m34.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m56.0s
+get_by_id                 • [   0% ] waiting    03m26.0s
+get_categories            • [   0% ] waiting    05m56.0s
+
+running (06m35.0s), 11/16 VUs, 96 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  63% ] 11/15 VUs  1m35.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m55.0s
+get_by_id                 • [   0% ] waiting    03m25.0s
+get_categories            • [   0% ] waiting    05m55.0s
+
+running (06m36.0s), 11/16 VUs, 96 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  64% ] 11/15 VUs  1m36.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m54.0s
+get_by_id                 • [   0% ] waiting    03m24.0s
+get_categories            • [   0% ] waiting    05m54.0s
+time="2026-03-12T14:26:51Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=wooden&categoryName=Footwear&size=20\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (06m37.0s), 12/16 VUs, 96 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  65% ] 12/15 VUs  1m37.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m53.0s
+get_by_id                 • [   0% ] waiting    03m23.0s
+get_categories            • [   0% ] waiting    05m53.0s
+time="2026-03-12T14:26:52Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=linen&categoryName=Kitchen%20%26%20Dining&size=20\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (06m38.0s), 12/16 VUs, 97 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  65% ] 12/15 VUs  1m38.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m52.0s
+get_by_id                 • [   0% ] waiting    03m22.0s
+get_categories            • [   0% ] waiting    05m52.0s
+time="2026-03-12T14:26:53Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=ceramic&categoryName=Women's%20Clothing&size=20\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (06m39.0s), 12/16 VUs, 98 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  66% ] 12/15 VUs  1m39.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m51.0s
+get_by_id                 • [   0% ] waiting    03m21.0s
+get_categories            • [   0% ] waiting    05m51.0s
+
+running (06m40.0s), 13/16 VUs, 100 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  67% ] 13/15 VUs  1m40.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m50.0s
+get_by_id                 • [   0% ] waiting    03m20.0s
+get_categories            • [   0% ] waiting    05m50.0s
+
+running (06m41.0s), 13/16 VUs, 100 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  67% ] 13/15 VUs  1m41.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m49.0s
+get_by_id                 • [   0% ] waiting    03m19.0s
+get_categories            • [   0% ] waiting    05m49.0s
+
+running (06m42.0s), 13/16 VUs, 100 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  68% ] 13/15 VUs  1m42.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m48.0s
+get_by_id                 • [   0% ] waiting    03m18.0s
+get_categories            • [   0% ] waiting    05m48.0s
+
+running (06m43.0s), 14/16 VUs, 100 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  69% ] 14/15 VUs  1m43.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m47.0s
+get_by_id                 • [   0% ] waiting    03m17.0s
+get_categories            • [   0% ] waiting    05m47.0s
+
+running (06m44.0s), 14/16 VUs, 100 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  69% ] 14/15 VUs  1m44.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m46.0s
+get_by_id                 • [   0% ] waiting    03m16.0s
+get_categories            • [   0% ] waiting    05m46.0s
+
+running (06m45.0s), 14/16 VUs, 100 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  70% ] 14/15 VUs  1m45.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m45.0s
+get_by_id                 • [   0% ] waiting    03m15.0s
+get_categories            • [   0% ] waiting    05m45.0s
+time="2026-03-12T14:27:00Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=suede&categoryName=Sports%20%26%20Outdoors&size=20\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (06m46.0s), 15/16 VUs, 100 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  71% ] 15/15 VUs  1m46.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m44.0s
+get_by_id                 • [   0% ] waiting    03m14.0s
+get_categories            • [   0% ] waiting    05m44.0s
+
+running (06m47.0s), 15/16 VUs, 101 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  71% ] 15/15 VUs  1m47.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m43.0s
+get_by_id                 • [   0% ] waiting    03m13.0s
+get_categories            • [   0% ] waiting    05m43.0s
+
+running (06m48.0s), 15/16 VUs, 102 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  72% ] 15/15 VUs  1m48.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m42.0s
+get_by_id                 • [   0% ] waiting    03m12.0s
+get_categories            • [   0% ] waiting    05m42.0s
+
+running (06m49.0s), 15/16 VUs, 102 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  73% ] 15/15 VUs  1m49.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m41.0s
+get_by_id                 • [   0% ] waiting    03m11.0s
+get_categories            • [   0% ] waiting    05m41.0s
+
+running (06m50.0s), 15/16 VUs, 103 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  73% ] 15/15 VUs  1m50.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m40.0s
+get_by_id                 • [   0% ] waiting    03m10.0s
+get_categories            • [   0% ] waiting    05m40.0s
+
+running (06m51.0s), 15/16 VUs, 103 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  74% ] 15/15 VUs  1m51.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m39.0s
+get_by_id                 • [   0% ] waiting    03m09.0s
+get_categories            • [   0% ] waiting    05m39.0s
+
+running (06m52.0s), 15/16 VUs, 103 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  75% ] 15/15 VUs  1m52.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m38.0s
+get_by_id                 • [   0% ] waiting    03m08.0s
+get_categories            • [   0% ] waiting    05m38.0s
+
+running (06m53.0s), 15/16 VUs, 104 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  75% ] 15/15 VUs  1m53.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m37.0s
+get_by_id                 • [   0% ] waiting    03m07.0s
+get_categories            • [   0% ] waiting    05m37.0s
+
+running (06m54.0s), 15/16 VUs, 104 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  76% ] 15/15 VUs  1m54.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m36.0s
+get_by_id                 • [   0% ] waiting    03m06.0s
+get_categories            • [   0% ] waiting    05m36.0s
+
+running (06m55.0s), 15/16 VUs, 104 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  77% ] 15/15 VUs  1m55.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m35.0s
+get_by_id                 • [   0% ] waiting    03m05.0s
+get_categories            • [   0% ] waiting    05m35.0s
+
+running (06m56.0s), 15/16 VUs, 106 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  77% ] 15/15 VUs  1m56.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m34.0s
+get_by_id                 • [   0% ] waiting    03m04.0s
+get_categories            • [   0% ] waiting    05m34.0s
+
+running (06m57.0s), 15/16 VUs, 106 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  78% ] 15/15 VUs  1m57.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m33.0s
+get_by_id                 • [   0% ] waiting    03m03.0s
+get_categories            • [   0% ] waiting    05m33.0s
+
+running (06m58.0s), 15/16 VUs, 106 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  79% ] 15/15 VUs  1m58.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m32.0s
+get_by_id                 • [   0% ] waiting    03m02.0s
+get_categories            • [   0% ] waiting    05m32.0s
+
+running (06m59.0s), 15/16 VUs, 107 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  79% ] 15/15 VUs  1m59.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m31.0s
+get_by_id                 • [   0% ] waiting    03m01.0s
+get_categories            • [   0% ] waiting    05m31.0s
+
+running (07m00.0s), 15/16 VUs, 107 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  80% ] 15/15 VUs  2m00.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m30.0s
+get_by_id                 • [   0% ] waiting    03m00.0s
+get_categories            • [   0% ] waiting    05m30.0s
+
+running (07m01.0s), 15/16 VUs, 107 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  81% ] 15/15 VUs  2m01.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m29.0s
+get_by_id                 • [   0% ] waiting    02m59.0s
+get_categories            • [   0% ] waiting    05m29.0s
+
+running (07m02.0s), 15/16 VUs, 107 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  81% ] 15/15 VUs  2m02.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m28.0s
+get_by_id                 • [   0% ] waiting    02m58.0s
+get_categories            • [   0% ] waiting    05m28.0s
+
+running (07m03.0s), 15/16 VUs, 107 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  82% ] 15/15 VUs  2m03.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m27.0s
+get_by_id                 • [   0% ] waiting    02m57.0s
+get_categories            • [   0% ] waiting    05m27.0s
+
+running (07m04.0s), 15/16 VUs, 108 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  83% ] 15/15 VUs  2m04.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m26.0s
+get_by_id                 • [   0% ] waiting    02m56.0s
+get_categories            • [   0% ] waiting    05m26.0s
+
+running (07m05.0s), 15/16 VUs, 110 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  83% ] 15/15 VUs  2m05.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m25.0s
+get_by_id                 • [   0% ] waiting    02m55.0s
+get_categories            • [   0% ] waiting    05m25.0s
+
+running (07m06.0s), 15/16 VUs, 111 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  84% ] 15/15 VUs  2m06.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m24.0s
+get_by_id                 • [   0% ] waiting    02m54.0s
+get_categories            • [   0% ] waiting    05m24.0s
+
+running (07m07.0s), 15/16 VUs, 111 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  85% ] 15/15 VUs  2m07.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m23.0s
+get_by_id                 • [   0% ] waiting    02m53.0s
+get_categories            • [   0% ] waiting    05m23.0s
+
+running (07m08.0s), 15/16 VUs, 111 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  85% ] 15/15 VUs  2m08.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m22.0s
+get_by_id                 • [   0% ] waiting    02m52.0s
+get_categories            • [   0% ] waiting    05m22.0s
+
+running (07m09.0s), 15/16 VUs, 111 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  86% ] 15/15 VUs  2m09.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m21.0s
+get_by_id                 • [   0% ] waiting    02m51.0s
+get_categories            • [   0% ] waiting    05m21.0s
+
+running (07m10.0s), 15/16 VUs, 111 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  87% ] 15/15 VUs  2m10.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m20.0s
+get_by_id                 • [   0% ] waiting    02m50.0s
+get_categories            • [   0% ] waiting    05m20.0s
+
+running (07m11.0s), 15/16 VUs, 114 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  87% ] 15/15 VUs  2m11.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m19.0s
+get_by_id                 • [   0% ] waiting    02m49.0s
+get_categories            • [   0% ] waiting    05m19.0s
+
+running (07m12.0s), 15/16 VUs, 114 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  88% ] 15/15 VUs  2m12.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m18.0s
+get_by_id                 • [   0% ] waiting    02m48.0s
+get_categories            • [   0% ] waiting    05m18.0s
+
+running (07m13.0s), 15/16 VUs, 114 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  89% ] 15/15 VUs  2m13.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m17.0s
+get_by_id                 • [   0% ] waiting    02m47.0s
+get_categories            • [   0% ] waiting    05m17.0s
+
+running (07m14.0s), 15/16 VUs, 115 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  89% ] 15/15 VUs  2m14.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m16.0s
+get_by_id                 • [   0% ] waiting    02m46.0s
+get_categories            • [   0% ] waiting    05m16.0s
+
+running (07m15.0s), 15/16 VUs, 115 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  90% ] 15/15 VUs  2m15.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m15.0s
+get_by_id                 • [   0% ] waiting    02m45.0s
+get_categories            • [   0% ] waiting    05m15.0s
+
+running (07m16.0s), 15/16 VUs, 115 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  91% ] 15/15 VUs  2m16.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m14.0s
+get_by_id                 • [   0% ] waiting    02m44.0s
+get_categories            • [   0% ] waiting    05m14.0s
+
+running (07m17.0s), 15/16 VUs, 115 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  91% ] 15/15 VUs  2m17.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m13.0s
+get_by_id                 • [   0% ] waiting    02m43.0s
+get_categories            • [   0% ] waiting    05m13.0s
+
+running (07m18.0s), 14/16 VUs, 116 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  92% ] 14/15 VUs  2m18.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m12.0s
+get_by_id                 • [   0% ] waiting    02m42.0s
+get_categories            • [   0% ] waiting    05m12.0s
+
+running (07m19.0s), 14/16 VUs, 117 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  93% ] 14/15 VUs  2m19.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m11.0s
+get_by_id                 • [   0% ] waiting    02m41.0s
+get_categories            • [   0% ] waiting    05m11.0s
+
+running (07m20.0s), 14/16 VUs, 117 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  93% ] 14/15 VUs  2m20.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m10.0s
+get_by_id                 • [   0% ] waiting    02m40.0s
+get_categories            • [   0% ] waiting    05m10.0s
+
+running (07m21.0s), 14/16 VUs, 118 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  94% ] 14/15 VUs  2m21.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m09.0s
+get_by_id                 • [   0% ] waiting    02m39.0s
+get_categories            • [   0% ] waiting    05m09.0s
+
+running (07m22.0s), 14/16 VUs, 118 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  95% ] 14/15 VUs  2m22.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m08.0s
+get_by_id                 • [   0% ] waiting    02m38.0s
+get_categories            • [   0% ] waiting    05m08.0s
+
+running (07m23.0s), 14/16 VUs, 118 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  95% ] 14/15 VUs  2m23.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m07.0s
+get_by_id                 • [   0% ] waiting    02m37.0s
+get_categories            • [   0% ] waiting    05m07.0s
+
+running (07m24.0s), 14/16 VUs, 119 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  96% ] 14/15 VUs  2m24.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m06.0s
+get_by_id                 • [   0% ] waiting    02m36.0s
+get_categories            • [   0% ] waiting    05m06.0s
+
+running (07m25.0s), 14/16 VUs, 119 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  97% ] 14/15 VUs  2m25.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m05.0s
+get_by_id                 • [   0% ] waiting    02m35.0s
+get_categories            • [   0% ] waiting    05m05.0s
+
+running (07m26.0s), 14/16 VUs, 119 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  97% ] 14/15 VUs  2m26.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m04.0s
+get_by_id                 • [   0% ] waiting    02m34.0s
+get_categories            • [   0% ] waiting    05m04.0s
+
+running (07m27.0s), 13/16 VUs, 121 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  98% ] 13/15 VUs  2m27.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m03.0s
+get_by_id                 • [   0% ] waiting    02m33.0s
+get_categories            • [   0% ] waiting    05m03.0s
+
+running (07m28.0s), 13/16 VUs, 121 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  99% ] 13/15 VUs  2m28.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m02.0s
+get_by_id                 • [   0% ] waiting    02m32.0s
+get_categories            • [   0% ] waiting    05m02.0s
+
+running (07m29.0s), 13/16 VUs, 121 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [  99% ] 13/15 VUs  2m29.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m01.0s
+get_by_id                 • [   0% ] waiting    02m31.0s
+get_categories            • [   0% ] waiting    05m01.0s
+
+running (07m30.0s), 12/16 VUs, 122 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search          [ 100% ] 12/15 VUs  2m30.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m00.0s
+get_by_id                 • [   0% ] waiting    02m30.0s
+get_categories            • [   0% ] waiting    05m00.0s
+
+running (07m31.0s), 13/16 VUs, 122 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ↓ [ 100% ] 12/15 VUs  2m30s
+autocomplete                [   1% ] 01/15 VUs  0m01.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    02m29.0s
+get_categories            • [   0% ] waiting    04m59.0s
+
+running (07m32.0s), 13/16 VUs, 122 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ↓ [ 100% ] 12/15 VUs  2m30s
+autocomplete                [   1% ] 01/15 VUs  0m02.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    02m28.0s
+get_categories            • [   0% ] waiting    04m58.0s
+
+running (07m33.0s), 13/16 VUs, 122 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ↓ [ 100% ] 12/15 VUs  2m30s
+autocomplete                [   2% ] 01/15 VUs  0m03.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    02m27.0s
+get_categories            • [   0% ] waiting    04m57.0s
+
+running (07m34.0s), 13/16 VUs, 122 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ↓ [ 100% ] 12/15 VUs  2m30s
+autocomplete                [   3% ] 01/15 VUs  0m04.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    02m26.0s
+get_categories            • [   0% ] waiting    04m56.0s
+
+running (07m35.0s), 12/16 VUs, 123 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ↓ [ 100% ] 12/15 VUs  2m30s
+autocomplete                [   3% ] 01/15 VUs  0m05.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    02m25.0s
+get_categories            • [   0% ] waiting    04m55.0s
+
+running (07m36.0s), 10/16 VUs, 125 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ↓ [ 100% ] 12/15 VUs  2m30s
+autocomplete                [   4% ] 01/15 VUs  0m06.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    02m24.0s
+get_categories            • [   0% ] waiting    04m54.0s
+
+running (07m37.0s), 09/16 VUs, 126 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ↓ [ 100% ] 12/15 VUs  2m30s
+autocomplete                [   5% ] 01/15 VUs  0m07.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    02m23.0s
+get_categories            • [   0% ] waiting    04m53.0s
+
+running (07m38.0s), 09/16 VUs, 126 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ↓ [ 100% ] 12/15 VUs  2m30s
+autocomplete                [   5% ] 01/15 VUs  0m08.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    02m22.0s
+get_categories            • [   0% ] waiting    04m52.0s
+
+running (07m39.0s), 09/16 VUs, 126 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ↓ [ 100% ] 12/15 VUs  2m30s
+autocomplete                [   6% ] 01/15 VUs  0m09.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    02m21.0s
+get_categories            • [   0% ] waiting    04m51.0s
+
+running (07m40.0s), 09/16 VUs, 126 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ↓ [ 100% ] 12/15 VUs  2m30s
+autocomplete                [   7% ] 01/15 VUs  0m10.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    02m20.0s
+get_categories            • [   0% ] waiting    04m50.0s
+
+running (07m41.0s), 09/16 VUs, 126 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ↓ [ 100% ] 12/15 VUs  2m30s
+autocomplete                [   7% ] 01/15 VUs  0m11.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    02m19.0s
+get_categories            • [   0% ] waiting    04m49.0s
+
+running (07m42.0s), 06/16 VUs, 129 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ↓ [ 100% ] 12/15 VUs  2m30s
+autocomplete                [   8% ] 01/15 VUs  0m12.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    02m18.0s
+get_categories            • [   0% ] waiting    04m48.0s
+
+running (07m43.0s), 06/16 VUs, 129 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ↓ [ 100% ] 12/15 VUs  2m30s
+autocomplete                [   9% ] 01/15 VUs  0m13.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    02m17.0s
+get_categories            • [   0% ] waiting    04m47.0s
+
+running (07m44.0s), 06/16 VUs, 129 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ↓ [ 100% ] 12/15 VUs  2m30s
+autocomplete                [   9% ] 01/15 VUs  0m14.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    02m16.0s
+get_categories            • [   0% ] waiting    04m46.0s
+
+running (07m45.0s), 05/16 VUs, 130 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ↓ [ 100% ] 12/15 VUs  2m30s
+autocomplete                [  10% ] 01/15 VUs  0m15.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    02m15.0s
+get_categories            • [   0% ] waiting    04m45.0s
+
+running (07m46.0s), 05/16 VUs, 130 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ↓ [ 100% ] 12/15 VUs  2m30s
+autocomplete                [  11% ] 01/15 VUs  0m16.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    02m14.0s
+get_categories            • [   0% ] waiting    04m44.0s
+
+running (07m47.0s), 05/16 VUs, 130 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ↓ [ 100% ] 12/15 VUs  2m30s
+autocomplete                [  11% ] 01/15 VUs  0m17.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    02m13.0s
+get_categories            • [   0% ] waiting    04m43.0s
+
+running (07m48.0s), 05/16 VUs, 130 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ↓ [ 100% ] 12/15 VUs  2m30s
+autocomplete                [  12% ] 01/15 VUs  0m18.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    02m12.0s
+get_categories            • [   0% ] waiting    04m42.0s
+
+running (07m49.0s), 05/16 VUs, 130 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ↓ [ 100% ] 12/15 VUs  2m30s
+autocomplete                [  13% ] 01/15 VUs  0m19.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    02m11.0s
+get_categories            • [   0% ] waiting    04m41.0s
+
+running (07m50.0s), 04/16 VUs, 131 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ↓ [ 100% ] 12/15 VUs  2m30s
+autocomplete                [  13% ] 01/15 VUs  0m20.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    02m10.0s
+get_categories            • [   0% ] waiting    04m40.0s
+
+running (07m51.0s), 04/16 VUs, 131 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ↓ [ 100% ] 12/15 VUs  2m30s
+autocomplete                [  14% ] 01/15 VUs  0m21.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    02m09.0s
+get_categories            • [   0% ] waiting    04m39.0s
+
+running (07m52.0s), 03/16 VUs, 132 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ↓ [ 100% ] 12/15 VUs  2m30s
+autocomplete                [  15% ] 01/15 VUs  0m22.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    02m08.0s
+get_categories            • [   0% ] waiting    04m38.0s
+
+running (07m53.0s), 04/16 VUs, 132 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ↓ [ 100% ] 12/15 VUs  2m30s
+autocomplete                [  15% ] 02/15 VUs  0m23.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    02m07.0s
+get_categories            • [   0% ] waiting    04m37.0s
+
+running (07m54.0s), 04/16 VUs, 132 complete and 3 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ↓ [ 100% ] 12/15 VUs  2m30s
+autocomplete                [  16% ] 02/15 VUs  0m24.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    02m06.0s
+get_categories            • [   0% ] waiting    04m36.0s
+
+running (07m55.0s), 03/16 VUs, 132 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ↓ [ 100% ] 12/15 VUs  2m30s
+autocomplete                [  17% ] 02/15 VUs  0m25.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    02m05.0s
+get_categories            • [   0% ] waiting    04m35.0s
+
+running (07m56.0s), 03/16 VUs, 132 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ↓ [ 100% ] 12/15 VUs  2m30s
+autocomplete                [  17% ] 02/15 VUs  0m26.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    02m04.0s
+get_categories            • [   0% ] waiting    04m34.0s
+
+running (07m57.0s), 03/16 VUs, 132 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ↓ [ 100% ] 12/15 VUs  2m30s
+autocomplete                [  18% ] 02/15 VUs  0m27.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    02m03.0s
+get_categories            • [   0% ] waiting    04m33.0s
+
+running (07m58.0s), 02/16 VUs, 133 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  19% ] 02/15 VUs  0m28.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    02m02.0s
+get_categories            • [   0% ] waiting    04m32.0s
+
+running (07m59.0s), 02/16 VUs, 133 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  19% ] 02/15 VUs  0m29.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    02m01.0s
+get_categories            • [   0% ] waiting    04m31.0s
+
+running (08m00.0s), 02/16 VUs, 133 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  20% ] 02/15 VUs  0m30.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    02m00.0s
+get_categories            • [   0% ] waiting    04m30.0s
+
+running (08m01.0s), 03/16 VUs, 134 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  21% ] 03/15 VUs  0m31.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m59.0s
+get_categories            • [   0% ] waiting    04m29.0s
+
+running (08m02.0s), 03/16 VUs, 134 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  21% ] 03/15 VUs  0m32.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m58.0s
+get_categories            • [   0% ] waiting    04m28.0s
+
+running (08m03.0s), 03/16 VUs, 134 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  22% ] 03/15 VUs  0m33.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m57.0s
+get_categories            • [   0% ] waiting    04m27.0s
+
+running (08m04.0s), 03/16 VUs, 134 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  23% ] 03/15 VUs  0m34.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m56.0s
+get_categories            • [   0% ] waiting    04m26.0s
+
+running (08m05.0s), 03/16 VUs, 134 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  23% ] 03/15 VUs  0m35.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m55.0s
+get_categories            • [   0% ] waiting    04m25.0s
+
+running (08m06.0s), 03/16 VUs, 134 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  24% ] 03/15 VUs  0m36.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m54.0s
+get_categories            • [   0% ] waiting    04m24.0s
+
+running (08m07.0s), 03/16 VUs, 134 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  25% ] 03/15 VUs  0m37.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m53.0s
+get_categories            • [   0% ] waiting    04m23.0s
+
+running (08m08.0s), 04/16 VUs, 134 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  25% ] 04/15 VUs  0m38.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m52.0s
+get_categories            • [   0% ] waiting    04m22.0s
+
+running (08m09.0s), 04/16 VUs, 134 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  26% ] 04/15 VUs  0m39.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m51.0s
+get_categories            • [   0% ] waiting    04m21.0s
+
+running (08m10.0s), 04/16 VUs, 134 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  27% ] 04/15 VUs  0m40.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m50.0s
+get_categories            • [   0% ] waiting    04m20.0s
+
+running (08m11.0s), 04/16 VUs, 134 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  27% ] 04/15 VUs  0m41.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m49.0s
+get_categories            • [   0% ] waiting    04m19.0s
+
+running (08m12.0s), 04/16 VUs, 134 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  28% ] 04/15 VUs  0m42.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m48.0s
+get_categories            • [   0% ] waiting    04m18.0s
+
+running (08m13.0s), 04/16 VUs, 134 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  29% ] 04/15 VUs  0m43.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m47.0s
+get_categories            • [   0% ] waiting    04m17.0s
+
+running (08m14.0s), 04/16 VUs, 134 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  29% ] 04/15 VUs  0m44.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m46.0s
+get_categories            • [   0% ] waiting    04m16.0s
+
+running (08m15.0s), 04/16 VUs, 134 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  30% ] 04/15 VUs  0m45.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m45.0s
+get_categories            • [   0% ] waiting    04m15.0s
+
+running (08m16.0s), 05/16 VUs, 134 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  31% ] 05/15 VUs  0m46.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m44.0s
+get_categories            • [   0% ] waiting    04m14.0s
+
+running (08m17.0s), 05/16 VUs, 134 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  31% ] 05/15 VUs  0m47.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m43.0s
+get_categories            • [   0% ] waiting    04m13.0s
+
+running (08m18.0s), 05/16 VUs, 134 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  32% ] 05/15 VUs  0m48.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m42.0s
+get_categories            • [   0% ] waiting    04m12.0s
+
+running (08m19.0s), 05/16 VUs, 134 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  33% ] 05/15 VUs  0m49.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m41.0s
+get_categories            • [   0% ] waiting    04m11.0s
+
+running (08m20.0s), 05/16 VUs, 134 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  33% ] 05/15 VUs  0m50.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m40.0s
+get_categories            • [   0% ] waiting    04m10.0s
+
+running (08m21.0s), 05/16 VUs, 134 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  34% ] 05/15 VUs  0m51.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m39.0s
+get_categories            • [   0% ] waiting    04m09.0s
+
+running (08m22.0s), 05/16 VUs, 134 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  35% ] 05/15 VUs  0m52.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m38.0s
+get_categories            • [   0% ] waiting    04m08.0s
+
+running (08m23.0s), 05/16 VUs, 134 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  35% ] 05/15 VUs  0m53.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m37.0s
+get_categories            • [   0% ] waiting    04m07.0s
+
+running (08m24.0s), 05/16 VUs, 135 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  36% ] 05/15 VUs  0m54.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m36.0s
+get_categories            • [   0% ] waiting    04m06.0s
+
+running (08m25.0s), 05/16 VUs, 135 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  37% ] 05/15 VUs  0m55.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m35.0s
+get_categories            • [   0% ] waiting    04m05.0s
+
+running (08m26.0s), 05/16 VUs, 135 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  37% ] 05/15 VUs  0m56.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m34.0s
+get_categories            • [   0% ] waiting    04m04.0s
+
+running (08m27.0s), 05/16 VUs, 135 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  38% ] 05/15 VUs  0m57.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m33.0s
+get_categories            • [   0% ] waiting    04m03.0s
+
+running (08m28.0s), 05/16 VUs, 135 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  39% ] 05/15 VUs  0m58.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m32.0s
+get_categories            • [   0% ] waiting    04m02.0s
+
+running (08m29.0s), 05/16 VUs, 135 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  39% ] 05/15 VUs  0m59.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m31.0s
+get_categories            • [   0% ] waiting    04m01.0s
+
+running (08m30.0s), 05/16 VUs, 135 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  40% ] 05/15 VUs  1m00.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m30.0s
+get_categories            • [   0% ] waiting    04m00.0s
+
+running (08m31.0s), 05/16 VUs, 136 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  41% ] 05/15 VUs  1m01.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m29.0s
+get_categories            • [   0% ] waiting    03m59.0s
+
+running (08m32.0s), 05/16 VUs, 137 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  41% ] 05/15 VUs  1m02.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m28.0s
+get_categories            • [   0% ] waiting    03m58.0s
+
+running (08m33.0s), 05/16 VUs, 137 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  42% ] 05/15 VUs  1m03.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m27.0s
+get_categories            • [   0% ] waiting    03m57.0s
+
+running (08m34.0s), 05/16 VUs, 137 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  43% ] 05/15 VUs  1m04.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m26.0s
+get_categories            • [   0% ] waiting    03m56.0s
+
+running (08m35.0s), 05/16 VUs, 137 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  43% ] 05/15 VUs  1m05.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m25.0s
+get_categories            • [   0% ] waiting    03m55.0s
+
+running (08m36.0s), 05/16 VUs, 137 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  44% ] 05/15 VUs  1m06.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m24.0s
+get_categories            • [   0% ] waiting    03m54.0s
+
+running (08m37.0s), 05/16 VUs, 137 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  45% ] 05/15 VUs  1m07.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m23.0s
+get_categories            • [   0% ] waiting    03m53.0s
+
+running (08m38.0s), 05/16 VUs, 137 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  45% ] 05/15 VUs  1m08.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m22.0s
+get_categories            • [   0% ] waiting    03m52.0s
+
+running (08m39.0s), 05/16 VUs, 138 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  46% ] 05/15 VUs  1m09.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m21.0s
+get_categories            • [   0% ] waiting    03m51.0s
+
+running (08m40.0s), 05/16 VUs, 138 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  47% ] 05/15 VUs  1m10.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m20.0s
+get_categories            • [   0% ] waiting    03m50.0s
+
+running (08m41.0s), 05/16 VUs, 138 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  47% ] 05/15 VUs  1m11.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m19.0s
+get_categories            • [   0% ] waiting    03m49.0s
+
+running (08m42.0s), 05/16 VUs, 138 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  48% ] 05/15 VUs  1m12.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m18.0s
+get_categories            • [   0% ] waiting    03m48.0s
+
+running (08m43.0s), 05/16 VUs, 138 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  49% ] 05/15 VUs  1m13.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m17.0s
+get_categories            • [   0% ] waiting    03m47.0s
+
+running (08m44.0s), 05/16 VUs, 138 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  49% ] 05/15 VUs  1m14.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m16.0s
+get_categories            • [   0% ] waiting    03m46.0s
+
+running (08m45.0s), 05/16 VUs, 138 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  50% ] 05/15 VUs  1m15.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m15.0s
+get_categories            • [   0% ] waiting    03m45.0s
+
+running (08m46.0s), 05/16 VUs, 139 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  51% ] 05/15 VUs  1m16.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m14.0s
+get_categories            • [   0% ] waiting    03m44.0s
+
+running (08m47.0s), 05/16 VUs, 139 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  51% ] 05/15 VUs  1m17.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m13.0s
+get_categories            • [   0% ] waiting    03m43.0s
+
+running (08m48.0s), 05/16 VUs, 139 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  52% ] 05/15 VUs  1m18.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m12.0s
+get_categories            • [   0% ] waiting    03m42.0s
+
+running (08m49.0s), 06/16 VUs, 139 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  53% ] 06/15 VUs  1m19.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m11.0s
+get_categories            • [   0% ] waiting    03m41.0s
+
+running (08m50.0s), 06/16 VUs, 139 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  53% ] 06/15 VUs  1m20.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m10.0s
+get_categories            • [   0% ] waiting    03m40.0s
+
+running (08m51.0s), 06/16 VUs, 139 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  54% ] 06/15 VUs  1m21.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m09.0s
+get_categories            • [   0% ] waiting    03m39.0s
+time="2026-03-12T14:29:06Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products/suggest?prefix=Bol&limit=10\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (08m52.0s), 07/16 VUs, 140 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  55% ] 07/15 VUs  1m22.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m08.0s
+get_categories            • [   0% ] waiting    03m38.0s
+
+running (08m53.0s), 07/16 VUs, 140 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  55% ] 07/15 VUs  1m23.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m07.0s
+get_categories            • [   0% ] waiting    03m37.0s
+
+running (08m54.0s), 07/16 VUs, 141 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  56% ] 07/15 VUs  1m24.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m06.0s
+get_categories            • [   0% ] waiting    03m36.0s
+time="2026-03-12T14:29:09Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products/suggest?prefix=Nat&limit=10\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (08m55.0s), 08/16 VUs, 142 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  57% ] 08/15 VUs  1m25.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m05.0s
+get_categories            • [   0% ] waiting    03m35.0s
+
+running (08m56.0s), 08/16 VUs, 142 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  57% ] 08/15 VUs  1m26.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m04.0s
+get_categories            • [   0% ] waiting    03m34.0s
+
+running (08m57.0s), 08/16 VUs, 142 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  58% ] 08/15 VUs  1m27.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m03.0s
+get_categories            • [   0% ] waiting    03m33.0s
+time="2026-03-12T14:29:12Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products/suggest?prefix=Ess&limit=10\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (08m58.0s), 09/16 VUs, 143 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  59% ] 09/15 VUs  1m28.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m02.0s
+get_categories            • [   0% ] waiting    03m32.0s
+
+running (08m59.0s), 09/16 VUs, 143 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  59% ] 09/15 VUs  1m29.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m01.0s
+get_categories            • [   0% ] waiting    03m31.0s
+
+running (09m00.0s), 09/16 VUs, 143 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  60% ] 09/15 VUs  1m30.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m00.0s
+get_categories            • [   0% ] waiting    03m30.0s
+
+running (09m01.0s), 10/16 VUs, 143 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  61% ] 10/15 VUs  1m31.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m59.0s
+get_categories            • [   0% ] waiting    03m29.0s
+
+running (09m02.0s), 10/16 VUs, 145 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  61% ] 10/15 VUs  1m32.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m58.0s
+get_categories            • [   0% ] waiting    03m28.0s
+
+running (09m03.0s), 10/16 VUs, 145 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  62% ] 10/15 VUs  1m33.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m57.0s
+get_categories            • [   0% ] waiting    03m27.0s
+
+running (09m04.0s), 11/16 VUs, 145 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  63% ] 11/15 VUs  1m34.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m56.0s
+get_categories            • [   0% ] waiting    03m26.0s
+
+running (09m05.0s), 11/16 VUs, 145 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  63% ] 11/15 VUs  1m35.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m55.0s
+get_categories            • [   0% ] waiting    03m25.0s
+
+running (09m06.0s), 11/16 VUs, 145 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  64% ] 11/15 VUs  1m36.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m54.0s
+get_categories            • [   0% ] waiting    03m24.0s
+
+running (09m07.0s), 12/16 VUs, 145 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  65% ] 12/15 VUs  1m37.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m53.0s
+get_categories            • [   0% ] waiting    03m23.0s
+
+running (09m08.0s), 12/16 VUs, 145 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  65% ] 12/15 VUs  1m38.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m52.0s
+get_categories            • [   0% ] waiting    03m22.0s
+
+running (09m09.0s), 12/16 VUs, 146 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  66% ] 12/15 VUs  1m39.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m51.0s
+get_categories            • [   0% ] waiting    03m21.0s
+
+running (09m10.0s), 13/16 VUs, 146 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  67% ] 13/15 VUs  1m40.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m50.0s
+get_categories            • [   0% ] waiting    03m20.0s
+
+running (09m11.0s), 13/16 VUs, 146 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  67% ] 13/15 VUs  1m41.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m49.0s
+get_categories            • [   0% ] waiting    03m19.0s
+
+running (09m12.0s), 13/16 VUs, 146 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  68% ] 13/15 VUs  1m42.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m48.0s
+get_categories            • [   0% ] waiting    03m18.0s
+time="2026-03-12T14:29:27Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products/suggest?prefix=Eli&limit=10\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (09m13.0s), 14/16 VUs, 147 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  69% ] 14/15 VUs  1m43.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m47.0s
+get_categories            • [   0% ] waiting    03m17.0s
+
+running (09m14.0s), 14/16 VUs, 147 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  69% ] 14/15 VUs  1m44.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m46.0s
+get_categories            • [   0% ] waiting    03m16.0s
+
+running (09m15.0s), 14/16 VUs, 147 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  70% ] 14/15 VUs  1m45.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m45.0s
+get_categories            • [   0% ] waiting    03m15.0s
+time="2026-03-12T14:29:30Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products/suggest?prefix=Lux&limit=10\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (09m16.0s), 15/16 VUs, 148 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  71% ] 15/15 VUs  1m46.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m44.0s
+get_categories            • [   0% ] waiting    03m14.0s
+
+running (09m17.0s), 15/16 VUs, 149 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  71% ] 15/15 VUs  1m47.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m43.0s
+get_categories            • [   0% ] waiting    03m13.0s
+
+running (09m18.0s), 15/16 VUs, 149 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  72% ] 15/15 VUs  1m48.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m42.0s
+get_categories            • [   0% ] waiting    03m12.0s
+
+running (09m19.0s), 15/16 VUs, 150 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  73% ] 15/15 VUs  1m49.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m41.0s
+get_categories            • [   0% ] waiting    03m11.0s
+
+running (09m20.0s), 15/16 VUs, 150 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  73% ] 15/15 VUs  1m50.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m40.0s
+get_categories            • [   0% ] waiting    03m10.0s
+
+running (09m21.0s), 15/16 VUs, 150 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  74% ] 15/15 VUs  1m51.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m39.0s
+get_categories            • [   0% ] waiting    03m09.0s
+
+running (09m22.0s), 15/16 VUs, 150 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  75% ] 15/15 VUs  1m52.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m38.0s
+get_categories            • [   0% ] waiting    03m08.0s
+
+running (09m23.0s), 15/16 VUs, 151 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  75% ] 15/15 VUs  1m53.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m37.0s
+get_categories            • [   0% ] waiting    03m07.0s
+
+running (09m24.0s), 15/16 VUs, 151 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  76% ] 15/15 VUs  1m54.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m36.0s
+get_categories            • [   0% ] waiting    03m06.0s
+
+running (09m25.0s), 15/16 VUs, 152 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  77% ] 15/15 VUs  1m55.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m35.0s
+get_categories            • [   0% ] waiting    03m05.0s
+
+running (09m26.0s), 15/16 VUs, 153 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  77% ] 15/15 VUs  1m56.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m34.0s
+get_categories            • [   0% ] waiting    03m04.0s
+
+running (09m27.0s), 15/16 VUs, 153 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  78% ] 15/15 VUs  1m57.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m33.0s
+get_categories            • [   0% ] waiting    03m03.0s
+
+running (09m28.0s), 15/16 VUs, 153 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  79% ] 15/15 VUs  1m58.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m32.0s
+get_categories            • [   0% ] waiting    03m02.0s
+
+running (09m29.0s), 15/16 VUs, 154 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  79% ] 15/15 VUs  1m59.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m31.0s
+get_categories            • [   0% ] waiting    03m01.0s
+
+running (09m30.0s), 15/16 VUs, 154 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  80% ] 15/15 VUs  2m00.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m30.0s
+get_categories            • [   0% ] waiting    03m00.0s
+
+running (09m31.0s), 15/16 VUs, 155 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  81% ] 15/15 VUs  2m01.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m29.0s
+get_categories            • [   0% ] waiting    02m59.0s
+
+running (09m32.0s), 15/16 VUs, 156 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  81% ] 15/15 VUs  2m02.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m28.0s
+get_categories            • [   0% ] waiting    02m58.0s
+
+running (09m33.0s), 15/16 VUs, 157 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  82% ] 15/15 VUs  2m03.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m27.0s
+get_categories            • [   0% ] waiting    02m57.0s
+
+running (09m34.0s), 15/16 VUs, 158 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  83% ] 15/15 VUs  2m04.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m26.0s
+get_categories            • [   0% ] waiting    02m56.0s
+
+running (09m35.0s), 15/16 VUs, 158 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  83% ] 15/15 VUs  2m05.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m25.0s
+get_categories            • [   0% ] waiting    02m55.0s
+
+running (09m36.0s), 15/16 VUs, 158 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  84% ] 15/15 VUs  2m06.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m24.0s
+get_categories            • [   0% ] waiting    02m54.0s
+
+running (09m37.0s), 15/16 VUs, 159 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  85% ] 15/15 VUs  2m07.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m23.0s
+get_categories            • [   0% ] waiting    02m53.0s
+
+running (09m38.0s), 15/16 VUs, 159 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  85% ] 15/15 VUs  2m08.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m22.0s
+get_categories            • [   0% ] waiting    02m52.0s
+
+running (09m39.0s), 15/16 VUs, 159 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  86% ] 15/15 VUs  2m09.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m21.0s
+get_categories            • [   0% ] waiting    02m51.0s
+
+running (09m40.0s), 15/16 VUs, 159 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  87% ] 15/15 VUs  2m10.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m20.0s
+get_categories            • [   0% ] waiting    02m50.0s
+
+running (09m41.0s), 15/16 VUs, 159 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  87% ] 15/15 VUs  2m11.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m19.0s
+get_categories            • [   0% ] waiting    02m49.0s
+
+running (09m42.0s), 15/16 VUs, 159 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  88% ] 15/15 VUs  2m12.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m18.0s
+get_categories            • [   0% ] waiting    02m48.0s
+
+running (09m43.0s), 15/16 VUs, 159 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  89% ] 15/15 VUs  2m13.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m17.0s
+get_categories            • [   0% ] waiting    02m47.0s
+
+running (09m44.0s), 15/16 VUs, 159 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  89% ] 15/15 VUs  2m14.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m16.0s
+get_categories            • [   0% ] waiting    02m46.0s
+
+running (09m45.0s), 15/16 VUs, 159 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  90% ] 15/15 VUs  2m15.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m15.0s
+get_categories            • [   0% ] waiting    02m45.0s
+
+running (09m46.0s), 15/16 VUs, 159 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  91% ] 15/15 VUs  2m16.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m14.0s
+get_categories            • [   0% ] waiting    02m44.0s
+
+running (09m47.0s), 15/16 VUs, 159 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  91% ] 15/15 VUs  2m17.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m13.0s
+get_categories            • [   0% ] waiting    02m43.0s
+
+running (09m48.0s), 15/16 VUs, 159 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  92% ] 15/15 VUs  2m18.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m12.0s
+get_categories            • [   0% ] waiting    02m42.0s
+
+running (09m49.0s), 15/16 VUs, 159 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  93% ] 15/15 VUs  2m19.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m11.0s
+get_categories            • [   0% ] waiting    02m41.0s
+
+running (09m50.0s), 15/16 VUs, 159 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  93% ] 15/15 VUs  2m20.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m10.0s
+get_categories            • [   0% ] waiting    02m40.0s
+
+running (09m51.0s), 15/16 VUs, 159 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  94% ] 15/15 VUs  2m21.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m09.0s
+get_categories            • [   0% ] waiting    02m39.0s
+
+running (09m52.0s), 15/16 VUs, 159 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  95% ] 15/15 VUs  2m22.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m08.0s
+get_categories            • [   0% ] waiting    02m38.0s
+
+running (09m53.0s), 15/16 VUs, 159 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  95% ] 15/15 VUs  2m23.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m07.0s
+get_categories            • [   0% ] waiting    02m37.0s
+
+running (09m54.0s), 15/16 VUs, 159 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  96% ] 15/15 VUs  2m24.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m06.0s
+get_categories            • [   0% ] waiting    02m36.0s
+
+running (09m55.0s), 15/16 VUs, 159 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  97% ] 15/15 VUs  2m25.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m05.0s
+get_categories            • [   0% ] waiting    02m35.0s
+
+running (09m56.0s), 15/16 VUs, 159 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  97% ] 15/15 VUs  2m26.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m04.0s
+get_categories            • [   0% ] waiting    02m34.0s
+
+running (09m57.0s), 15/16 VUs, 159 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  98% ] 15/15 VUs  2m27.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m03.0s
+get_categories            • [   0% ] waiting    02m33.0s
+
+running (09m58.0s), 15/16 VUs, 159 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  99% ] 15/15 VUs  2m28.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m02.0s
+get_categories            • [   0% ] waiting    02m32.0s
+
+running (09m59.0s), 15/16 VUs, 159 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [  99% ] 15/15 VUs  2m29.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m01.0s
+get_categories            • [   0% ] waiting    02m31.0s
+
+running (10m00.0s), 15/16 VUs, 159 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete                [ 100% ] 15/15 VUs  2m30.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m00.0s
+get_categories            • [   0% ] waiting    02m30.0s
+
+running (10m01.0s), 16/16 VUs, 159 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ↓ [ 100% ] 15/15 VUs  2m30s
+get_by_id                   [   1% ] 01/15 VUs  0m01.0s/2m30.0s
+get_categories            • [   0% ] waiting    02m29.0s
+
+running (10m02.0s), 16/16 VUs, 159 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ↓ [ 100% ] 15/15 VUs  2m30s
+get_by_id                   [   1% ] 01/15 VUs  0m02.0s/2m30.0s
+get_categories            • [   0% ] waiting    02m28.0s
+
+running (10m03.0s), 16/16 VUs, 159 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ↓ [ 100% ] 15/15 VUs  2m30s
+get_by_id                   [   2% ] 01/15 VUs  0m03.0s/2m30.0s
+get_categories            • [   0% ] waiting    02m27.0s
+
+running (10m04.0s), 16/16 VUs, 159 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ↓ [ 100% ] 15/15 VUs  2m30s
+get_by_id                   [   3% ] 01/15 VUs  0m04.0s/2m30.0s
+get_categories            • [   0% ] waiting    02m26.0s
+
+running (10m05.0s), 16/16 VUs, 159 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ↓ [ 100% ] 15/15 VUs  2m30s
+get_by_id                   [   3% ] 01/15 VUs  0m05.0s/2m30.0s
+get_categories            • [   0% ] waiting    02m25.0s
+
+running (10m06.0s), 16/16 VUs, 159 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ↓ [ 100% ] 15/15 VUs  2m30s
+get_by_id                   [   4% ] 01/15 VUs  0m06.0s/2m30.0s
+get_categories            • [   0% ] waiting    02m24.0s
+
+running (10m07.0s), 16/16 VUs, 159 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ↓ [ 100% ] 15/15 VUs  2m30s
+get_by_id                   [   5% ] 01/15 VUs  0m07.0s/2m30.0s
+get_categories            • [   0% ] waiting    02m23.0s
+
+running (10m08.0s), 16/16 VUs, 159 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ↓ [ 100% ] 15/15 VUs  2m30s
+get_by_id                   [   5% ] 01/15 VUs  0m08.0s/2m30.0s
+get_categories            • [   0% ] waiting    02m22.0s
+time="2026-03-12T14:30:23Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products/suggest?prefix=Bol&limit=10\": request timeout"
+
+running (10m09.0s), 16/16 VUs, 159 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ↓ [ 100% ] 15/15 VUs  2m30s
+get_by_id                   [   6% ] 01/15 VUs  0m09.0s/2m30.0s
+get_categories            • [   0% ] waiting    02m21.0s
+time="2026-03-12T14:30:24Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products/suggest?prefix=Sle&limit=10\": request timeout"
+
+running (10m10.0s), 14/16 VUs, 161 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ↓ [ 100% ] 15/15 VUs  2m30s
+get_by_id                   [   7% ] 01/15 VUs  0m10.0s/2m30.0s
+get_categories            • [   0% ] waiting    02m20.0s
+
+running (10m11.0s), 14/16 VUs, 161 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ↓ [ 100% ] 15/15 VUs  2m30s
+get_by_id                   [   7% ] 01/15 VUs  0m11.0s/2m30.0s
+get_categories            • [   0% ] waiting    02m19.0s
+
+running (10m12.0s), 14/16 VUs, 161 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ↓ [ 100% ] 15/15 VUs  2m30s
+get_by_id                   [   8% ] 01/15 VUs  0m12.0s/2m30.0s
+get_categories            • [   0% ] waiting    02m18.0s
+time="2026-03-12T14:30:27Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products/suggest?prefix=Com&limit=10\": request timeout"
+
+running (10m13.0s), 14/16 VUs, 161 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ↓ [ 100% ] 15/15 VUs  2m30s
+get_by_id                   [   9% ] 01/15 VUs  0m13.0s/2m30.0s
+get_categories            • [   0% ] waiting    02m17.0s
+
+running (10m14.0s), 13/16 VUs, 162 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ↓ [ 100% ] 15/15 VUs  2m30s
+get_by_id                   [   9% ] 01/15 VUs  0m14.0s/2m30.0s
+get_categories            • [   0% ] waiting    02m16.0s
+
+running (10m15.0s), 13/16 VUs, 162 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ↓ [ 100% ] 15/15 VUs  2m30s
+get_by_id                   [  10% ] 01/15 VUs  0m15.0s/2m30.0s
+get_categories            • [   0% ] waiting    02m15.0s
+time="2026-03-12T14:30:30Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products/suggest?prefix=Pro&limit=10\": request timeout"
+
+running (10m16.0s), 13/16 VUs, 162 complete and 4 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ↓ [ 100% ] 15/15 VUs  2m30s
+get_by_id                   [  11% ] 01/15 VUs  0m16.0s/2m30.0s
+get_categories            • [   0% ] waiting    02m14.0s
+time="2026-03-12T14:30:31Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products/suggest?prefix=Mod&limit=10\": request timeout"
+
+running (10m17.0s), 11/16 VUs, 163 complete and 5 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ↓ [ 100% ] 15/15 VUs  2m30s
+get_by_id                   [  11% ] 01/15 VUs  0m17.0s/2m30.0s
+get_categories            • [   0% ] waiting    02m13.0s
+
+running (10m18.0s), 11/16 VUs, 163 complete and 5 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ↓ [ 100% ] 15/15 VUs  2m30s
+get_by_id                   [  12% ] 01/15 VUs  0m18.0s/2m30.0s
+get_categories            • [   0% ] waiting    02m12.0s
+time="2026-03-12T14:30:33Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products/suggest?prefix=Lux&limit=10\": request timeout"
+
+running (10m19.0s), 11/16 VUs, 163 complete and 5 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ↓ [ 100% ] 15/15 VUs  2m30s
+get_by_id                   [  13% ] 01/15 VUs  0m19.0s/2m30.0s
+get_categories            • [   0% ] waiting    02m11.0s
+
+running (10m20.0s), 09/16 VUs, 164 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ↓ [ 100% ] 15/15 VUs  2m30s
+get_by_id                   [  13% ] 01/15 VUs  0m20.0s/2m30.0s
+get_categories            • [   0% ] waiting    02m10.0s
+
+running (10m21.0s), 08/16 VUs, 164 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ↓ [ 100% ] 15/15 VUs  2m30s
+get_by_id                   [  14% ] 01/15 VUs  0m21.0s/2m30.0s
+get_categories            • [   0% ] waiting    02m09.0s
+
+running (10m22.0s), 07/16 VUs, 164 complete and 8 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ↓ [ 100% ] 15/15 VUs  2m30s
+get_by_id                   [  15% ] 01/15 VUs  0m22.0s/2m30.0s
+get_categories            • [   0% ] waiting    02m08.0s
+time="2026-03-12T14:30:37Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products/suggest?prefix=Ess&limit=10\": request timeout"
+
+running (10m23.0s), 06/16 VUs, 165 complete and 9 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ↓ [ 100% ] 15/15 VUs  2m30s
+get_by_id                   [  15% ] 02/15 VUs  0m23.0s/2m30.0s
+get_categories            • [   0% ] waiting    02m07.0s
+
+running (10m24.0s), 05/16 VUs, 165 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ↓ [ 100% ] 15/15 VUs  2m30s
+get_by_id                   [  16% ] 02/15 VUs  0m24.0s/2m30.0s
+get_categories            • [   0% ] waiting    02m06.0s
+time="2026-03-12T14:30:39Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products/suggest?prefix=Lux&limit=10\": request timeout"
+
+running (10m25.0s), 04/16 VUs, 166 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ↓ [ 100% ] 15/15 VUs  2m30s
+get_by_id                   [  17% ] 02/15 VUs  0m25.0s/2m30.0s
+get_categories            • [   0% ] waiting    02m05.0s
+
+running (10m26.0s), 04/16 VUs, 166 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ↓ [ 100% ] 15/15 VUs  2m30s
+get_by_id                   [  17% ] 02/15 VUs  0m26.0s/2m30.0s
+get_categories            • [   0% ] waiting    02m04.0s
+
+running (10m27.0s), 04/16 VUs, 166 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ↓ [ 100% ] 15/15 VUs  2m30s
+get_by_id                   [  18% ] 02/15 VUs  0m27.0s/2m30.0s
+get_categories            • [   0% ] waiting    02m03.0s
+
+running (10m28.0s), 04/16 VUs, 166 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ↓ [ 100% ] 15/15 VUs  2m30s
+get_by_id                   [  19% ] 02/15 VUs  0m28.0s/2m30.0s
+get_categories            • [   0% ] waiting    02m02.0s
+
+running (10m29.0s), 03/16 VUs, 166 complete and 11 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ↓ [ 100% ] 15/15 VUs  2m30s
+get_by_id                   [  19% ] 02/15 VUs  0m29.0s/2m30.0s
+get_categories            • [   0% ] waiting    02m01.0s
+
+running (10m30.0s), 03/16 VUs, 166 complete and 11 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ↓ [ 100% ] 15/15 VUs  2m30s
+get_by_id                   [  20% ] 02/15 VUs  0m30.0s/2m30.0s
+get_categories            • [   0% ] waiting    02m00.0s
+
+running (10m31.0s), 03/16 VUs, 166 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  21% ] 03/15 VUs  0m31.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m59.0s
+
+running (10m32.0s), 03/16 VUs, 166 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  21% ] 03/15 VUs  0m32.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m58.0s
+
+running (10m33.0s), 03/16 VUs, 166 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  22% ] 03/15 VUs  0m33.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m57.0s
+
+running (10m34.0s), 03/16 VUs, 166 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  23% ] 03/15 VUs  0m34.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m56.0s
+
+running (10m35.0s), 03/16 VUs, 166 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  23% ] 03/15 VUs  0m35.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m55.0s
+
+running (10m36.0s), 03/16 VUs, 166 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  24% ] 03/15 VUs  0m36.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m54.0s
+
+running (10m37.0s), 03/16 VUs, 166 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  25% ] 03/15 VUs  0m37.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m53.0s
+
+running (10m38.0s), 04/16 VUs, 166 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  25% ] 04/15 VUs  0m38.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m52.0s
+
+running (10m39.0s), 04/16 VUs, 166 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  26% ] 04/15 VUs  0m39.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m51.0s
+
+running (10m40.0s), 04/16 VUs, 166 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  27% ] 04/15 VUs  0m40.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m50.0s
+
+running (10m41.0s), 04/16 VUs, 166 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  27% ] 04/15 VUs  0m41.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m49.0s
+
+running (10m42.0s), 04/16 VUs, 166 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  28% ] 04/15 VUs  0m42.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m48.0s
+
+running (10m43.0s), 04/16 VUs, 166 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  29% ] 04/15 VUs  0m43.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m47.0s
+
+running (10m44.0s), 04/16 VUs, 166 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  29% ] 04/15 VUs  0m44.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m46.0s
+
+running (10m45.0s), 04/16 VUs, 166 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  30% ] 04/15 VUs  0m45.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m45.0s
+
+running (10m46.0s), 05/16 VUs, 166 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  31% ] 05/15 VUs  0m46.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m44.0s
+
+running (10m47.0s), 05/16 VUs, 166 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  31% ] 05/15 VUs  0m47.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m43.0s
+
+running (10m48.0s), 05/16 VUs, 166 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  32% ] 05/15 VUs  0m48.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m42.0s
+
+running (10m49.0s), 05/16 VUs, 166 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  33% ] 05/15 VUs  0m49.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m41.0s
+
+running (10m50.0s), 05/16 VUs, 166 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  33% ] 05/15 VUs  0m50.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m40.0s
+
+running (10m51.0s), 05/16 VUs, 166 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  34% ] 05/15 VUs  0m51.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m39.0s
+
+running (10m52.0s), 05/16 VUs, 166 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  35% ] 05/15 VUs  0m52.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m38.0s
+
+running (10m53.0s), 05/16 VUs, 166 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  35% ] 05/15 VUs  0m53.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m37.0s
+
+running (10m54.0s), 05/16 VUs, 166 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  36% ] 05/15 VUs  0m54.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m36.0s
+
+running (10m55.0s), 05/16 VUs, 166 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  37% ] 05/15 VUs  0m55.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m35.0s
+
+running (10m56.0s), 05/16 VUs, 166 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  37% ] 05/15 VUs  0m56.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m34.0s
+
+running (10m57.0s), 05/16 VUs, 166 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  38% ] 05/15 VUs  0m57.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m33.0s
+
+running (10m58.0s), 05/16 VUs, 166 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  39% ] 05/15 VUs  0m58.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m32.0s
+
+running (10m59.0s), 05/16 VUs, 166 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  39% ] 05/15 VUs  0m59.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m31.0s
+
+running (11m00.0s), 05/16 VUs, 166 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  40% ] 05/15 VUs  1m00.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m30.0s
+time="2026-03-12T14:31:15Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?size=1\": request timeout"
+
+running (11m01.0s), 05/16 VUs, 166 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  41% ] 05/15 VUs  1m01.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m29.0s
+time="2026-03-12T14:31:16Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?size=1\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (11m02.0s), 05/16 VUs, 168 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  41% ] 05/15 VUs  1m02.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m28.0s
+
+running (11m03.0s), 05/16 VUs, 169 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  42% ] 05/15 VUs  1m03.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m27.0s
+
+running (11m04.0s), 05/16 VUs, 169 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  43% ] 05/15 VUs  1m04.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m26.0s
+
+running (11m05.0s), 05/16 VUs, 169 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  43% ] 05/15 VUs  1m05.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m25.0s
+
+running (11m06.0s), 05/16 VUs, 169 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  44% ] 05/15 VUs  1m06.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m24.0s
+
+running (11m07.0s), 05/16 VUs, 169 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  45% ] 05/15 VUs  1m07.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m23.0s
+
+running (11m08.0s), 05/16 VUs, 169 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  45% ] 05/15 VUs  1m08.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m22.0s
+
+running (11m09.0s), 05/16 VUs, 169 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  46% ] 05/15 VUs  1m09.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m21.0s
+
+running (11m10.0s), 05/16 VUs, 169 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  47% ] 05/15 VUs  1m10.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m20.0s
+
+running (11m11.0s), 05/16 VUs, 169 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  47% ] 05/15 VUs  1m11.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m19.0s
+
+running (11m12.0s), 05/16 VUs, 169 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  48% ] 05/15 VUs  1m12.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m18.0s
+
+running (11m13.0s), 05/16 VUs, 169 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  49% ] 05/15 VUs  1m13.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m17.0s
+
+running (11m14.0s), 05/16 VUs, 169 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  49% ] 05/15 VUs  1m14.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m16.0s
+
+running (11m15.0s), 05/16 VUs, 169 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  50% ] 05/15 VUs  1m15.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m15.0s
+
+running (11m16.0s), 05/16 VUs, 169 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  51% ] 05/15 VUs  1m16.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m14.0s
+
+running (11m17.0s), 05/16 VUs, 169 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  51% ] 05/15 VUs  1m17.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m13.0s
+
+running (11m18.0s), 05/16 VUs, 169 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  52% ] 05/15 VUs  1m18.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m12.0s
+
+running (11m19.0s), 06/16 VUs, 169 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  53% ] 06/15 VUs  1m19.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m11.0s
+
+running (11m20.0s), 06/16 VUs, 169 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  53% ] 06/15 VUs  1m20.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m10.0s
+
+running (11m21.0s), 06/16 VUs, 169 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  54% ] 06/15 VUs  1m21.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m09.0s
+
+running (11m22.0s), 07/16 VUs, 169 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  55% ] 07/15 VUs  1m22.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m08.0s
+time="2026-03-12T14:31:37Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?size=1\": request timeout"
+
+running (11m23.0s), 07/16 VUs, 169 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  55% ] 07/15 VUs  1m23.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m07.0s
+
+running (11m24.0s), 07/16 VUs, 170 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  56% ] 07/15 VUs  1m24.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m06.0s
+
+running (11m25.0s), 08/16 VUs, 170 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  57% ] 08/15 VUs  1m25.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m05.0s
+
+running (11m26.0s), 08/16 VUs, 170 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  57% ] 08/15 VUs  1m26.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m04.0s
+
+running (11m27.0s), 08/16 VUs, 170 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  58% ] 08/15 VUs  1m27.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m03.0s
+
+running (11m28.0s), 09/16 VUs, 170 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  59% ] 09/15 VUs  1m28.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m02.0s
+
+running (11m29.0s), 09/16 VUs, 170 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  59% ] 09/15 VUs  1m29.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m01.0s
+
+running (11m30.0s), 09/16 VUs, 170 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  60% ] 09/15 VUs  1m30.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m00.0s
+
+running (11m31.0s), 10/16 VUs, 170 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  61% ] 10/15 VUs  1m31.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m59.0s
+
+running (11m32.0s), 10/16 VUs, 170 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  61% ] 10/15 VUs  1m32.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m58.0s
+
+running (11m33.0s), 10/16 VUs, 171 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  62% ] 10/15 VUs  1m33.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m57.0s
+
+running (11m34.0s), 11/16 VUs, 172 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  63% ] 11/15 VUs  1m34.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m56.0s
+
+running (11m35.0s), 11/16 VUs, 172 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  63% ] 11/15 VUs  1m35.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m55.0s
+
+running (11m36.0s), 11/16 VUs, 172 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  64% ] 11/15 VUs  1m36.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m54.0s
+
+running (11m37.0s), 12/16 VUs, 172 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  65% ] 12/15 VUs  1m37.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m53.0s
+time="2026-03-12T14:31:52Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?size=1\": request timeout"
+
+running (11m38.0s), 12/16 VUs, 172 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  65% ] 12/15 VUs  1m38.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m52.0s
+
+running (11m39.0s), 12/16 VUs, 173 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  66% ] 12/15 VUs  1m39.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m51.0s
+time="2026-03-12T14:31:54Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?size=1\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (11m40.0s), 13/16 VUs, 173 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  67% ] 13/15 VUs  1m40.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m50.0s
+
+running (11m41.0s), 13/16 VUs, 174 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  67% ] 13/15 VUs  1m41.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m49.0s
+
+running (11m42.0s), 13/16 VUs, 174 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  68% ] 13/15 VUs  1m42.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m48.0s
+
+running (11m43.0s), 14/16 VUs, 174 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  69% ] 14/15 VUs  1m43.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m47.0s
+
+running (11m44.0s), 14/16 VUs, 174 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  69% ] 14/15 VUs  1m44.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m46.0s
+
+running (11m45.0s), 14/16 VUs, 174 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  70% ] 14/15 VUs  1m45.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m45.0s
+time="2026-03-12T14:32:00Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?size=1\": request timeout"
+
+running (11m46.0s), 15/16 VUs, 174 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  71% ] 15/15 VUs  1m46.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m44.0s
+time="2026-03-12T14:32:01Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?size=1\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (11m47.0s), 15/16 VUs, 175 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  71% ] 15/15 VUs  1m47.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m43.0s
+time="2026-03-12T14:32:02Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?size=1\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (11m48.0s), 15/16 VUs, 176 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  72% ] 15/15 VUs  1m48.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m42.0s
+
+running (11m49.0s), 15/16 VUs, 177 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  73% ] 15/15 VUs  1m49.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m41.0s
+
+running (11m50.0s), 15/16 VUs, 178 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  73% ] 15/15 VUs  1m50.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m40.0s
+
+running (11m51.0s), 15/16 VUs, 178 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  74% ] 15/15 VUs  1m51.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m39.0s
+
+running (11m52.0s), 15/16 VUs, 178 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  75% ] 15/15 VUs  1m52.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m38.0s
+
+running (11m53.0s), 15/16 VUs, 179 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  75% ] 15/15 VUs  1m53.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m37.0s
+
+running (11m54.0s), 15/16 VUs, 179 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  76% ] 15/15 VUs  1m54.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m36.0s
+
+running (11m55.0s), 15/16 VUs, 179 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  77% ] 15/15 VUs  1m55.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m35.0s
+
+running (11m56.0s), 15/16 VUs, 180 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  77% ] 15/15 VUs  1m56.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m34.0s
+
+running (11m57.0s), 15/16 VUs, 180 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  78% ] 15/15 VUs  1m57.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m33.0s
+
+running (11m58.0s), 15/16 VUs, 180 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  79% ] 15/15 VUs  1m58.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m32.0s
+
+running (11m59.0s), 15/16 VUs, 181 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  79% ] 15/15 VUs  1m59.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m31.0s
+
+running (12m00.0s), 15/16 VUs, 181 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  80% ] 15/15 VUs  2m00.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m30.0s
+
+running (12m01.0s), 15/16 VUs, 181 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  81% ] 15/15 VUs  2m01.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m29.0s
+
+running (12m02.0s), 15/16 VUs, 182 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  81% ] 15/15 VUs  2m02.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m28.0s
+
+running (12m03.0s), 15/16 VUs, 182 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  82% ] 15/15 VUs  2m03.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m27.0s
+
+running (12m04.0s), 15/16 VUs, 183 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  83% ] 15/15 VUs  2m04.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m26.0s
+
+running (12m05.0s), 15/16 VUs, 185 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  83% ] 15/15 VUs  2m05.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m25.0s
+
+running (12m06.0s), 15/16 VUs, 185 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  84% ] 15/15 VUs  2m06.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m24.0s
+
+running (12m07.0s), 15/16 VUs, 185 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  85% ] 15/15 VUs  2m07.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m23.0s
+
+running (12m08.0s), 15/16 VUs, 186 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  85% ] 15/15 VUs  2m08.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m22.0s
+
+running (12m09.0s), 15/16 VUs, 186 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  86% ] 15/15 VUs  2m09.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m21.0s
+
+running (12m10.0s), 15/16 VUs, 187 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  87% ] 15/15 VUs  2m10.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m20.0s
+
+running (12m11.0s), 15/16 VUs, 187 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  87% ] 15/15 VUs  2m11.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m19.0s
+
+running (12m12.0s), 15/16 VUs, 188 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  88% ] 15/15 VUs  2m12.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m18.0s
+
+running (12m13.0s), 15/16 VUs, 188 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  89% ] 15/15 VUs  2m13.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m17.0s
+
+running (12m14.0s), 15/16 VUs, 189 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  89% ] 15/15 VUs  2m14.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m16.0s
+
+running (12m15.0s), 15/16 VUs, 189 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  90% ] 15/15 VUs  2m15.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m15.0s
+
+running (12m16.0s), 15/16 VUs, 189 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  91% ] 15/15 VUs  2m16.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m14.0s
+
+running (12m17.0s), 14/16 VUs, 190 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  91% ] 14/15 VUs  2m17.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m13.0s
+
+running (12m18.0s), 14/16 VUs, 190 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  92% ] 14/15 VUs  2m18.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m12.0s
+
+running (12m19.0s), 14/16 VUs, 190 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  93% ] 14/15 VUs  2m19.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m11.0s
+
+running (12m20.0s), 14/16 VUs, 191 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  93% ] 14/15 VUs  2m20.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m10.0s
+
+running (12m21.0s), 14/16 VUs, 192 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  94% ] 14/15 VUs  2m21.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m09.0s
+
+running (12m22.0s), 14/16 VUs, 192 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  95% ] 14/15 VUs  2m22.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m08.0s
+
+running (12m23.0s), 14/16 VUs, 192 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  95% ] 14/15 VUs  2m23.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m07.0s
+time="2026-03-12T14:32:38Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?size=1\": request timeout"
+
+running (12m24.0s), 14/16 VUs, 193 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  96% ] 14/15 VUs  2m24.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m06.0s
+time="2026-03-12T14:32:39Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?size=1\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (12m25.0s), 14/16 VUs, 194 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  97% ] 14/15 VUs  2m25.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m05.0s
+
+running (12m26.0s), 14/16 VUs, 195 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  97% ] 14/15 VUs  2m26.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m04.0s
+
+running (12m27.0s), 13/16 VUs, 196 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  98% ] 13/15 VUs  2m27.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m03.0s
+
+running (12m28.0s), 13/16 VUs, 196 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  99% ] 13/15 VUs  2m28.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m02.0s
+
+running (12m29.0s), 13/16 VUs, 196 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [  99% ] 13/15 VUs  2m29.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m01.0s
+
+running (12m30.0s), 12/16 VUs, 197 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                   [ 100% ] 12/15 VUs  2m30.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m00.0s
+
+running (12m31.0s), 13/16 VUs, 197 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ↓ [ 100% ] 12/15 VUs  2m30s
+get_categories              [   1% ] 01/15 VUs  0m01.0s/2m30.0s
+
+running (12m32.0s), 13/16 VUs, 197 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ↓ [ 100% ] 12/15 VUs  2m30s
+get_categories              [   1% ] 01/15 VUs  0m02.0s/2m30.0s
+
+running (12m33.0s), 12/16 VUs, 198 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ↓ [ 100% ] 12/15 VUs  2m30s
+get_categories              [   2% ] 01/15 VUs  0m03.0s/2m30.0s
+
+running (12m34.0s), 12/16 VUs, 198 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ↓ [ 100% ] 12/15 VUs  2m30s
+get_categories              [   3% ] 01/15 VUs  0m04.0s/2m30.0s
+
+running (12m35.0s), 11/16 VUs, 199 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ↓ [ 100% ] 12/15 VUs  2m30s
+get_categories              [   3% ] 01/15 VUs  0m05.0s/2m30.0s
+
+running (12m36.0s), 09/16 VUs, 201 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ↓ [ 100% ] 12/15 VUs  2m30s
+get_categories              [   4% ] 01/15 VUs  0m06.0s/2m30.0s
+
+running (12m37.0s), 09/16 VUs, 201 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ↓ [ 100% ] 12/15 VUs  2m30s
+get_categories              [   5% ] 01/15 VUs  0m07.0s/2m30.0s
+
+running (12m38.0s), 09/16 VUs, 201 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ↓ [ 100% ] 12/15 VUs  2m30s
+get_categories              [   5% ] 01/15 VUs  0m08.0s/2m30.0s
+
+running (12m39.0s), 08/16 VUs, 202 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ↓ [ 100% ] 12/15 VUs  2m30s
+get_categories              [   6% ] 01/15 VUs  0m09.0s/2m30.0s
+
+running (12m40.0s), 08/16 VUs, 202 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ↓ [ 100% ] 12/15 VUs  2m30s
+get_categories              [   7% ] 01/15 VUs  0m10.0s/2m30.0s
+
+running (12m41.0s), 07/16 VUs, 203 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ↓ [ 100% ] 12/15 VUs  2m30s
+get_categories              [   7% ] 01/15 VUs  0m11.0s/2m30.0s
+
+running (12m42.0s), 07/16 VUs, 203 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ↓ [ 100% ] 12/15 VUs  2m30s
+get_categories              [   8% ] 01/15 VUs  0m12.0s/2m30.0s
+
+running (12m43.0s), 06/16 VUs, 204 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ↓ [ 100% ] 12/15 VUs  2m30s
+get_categories              [   9% ] 01/15 VUs  0m13.0s/2m30.0s
+
+running (12m44.0s), 06/16 VUs, 204 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ↓ [ 100% ] 12/15 VUs  2m30s
+get_categories              [   9% ] 01/15 VUs  0m14.0s/2m30.0s
+
+running (12m45.0s), 05/16 VUs, 205 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ↓ [ 100% ] 12/15 VUs  2m30s
+get_categories              [  10% ] 01/15 VUs  0m15.0s/2m30.0s
+
+running (12m46.0s), 05/16 VUs, 205 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ↓ [ 100% ] 12/15 VUs  2m30s
+get_categories              [  11% ] 01/15 VUs  0m16.0s/2m30.0s
+
+running (12m47.0s), 05/16 VUs, 205 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ↓ [ 100% ] 12/15 VUs  2m30s
+get_categories              [  11% ] 01/15 VUs  0m17.0s/2m30.0s
+
+running (12m48.0s), 05/16 VUs, 205 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ↓ [ 100% ] 12/15 VUs  2m30s
+get_categories              [  12% ] 01/15 VUs  0m18.0s/2m30.0s
+
+running (12m49.0s), 05/16 VUs, 205 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ↓ [ 100% ] 12/15 VUs  2m30s
+get_categories              [  13% ] 01/15 VUs  0m19.0s/2m30.0s
+
+running (12m50.0s), 05/16 VUs, 205 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ↓ [ 100% ] 12/15 VUs  2m30s
+get_categories              [  13% ] 01/15 VUs  0m20.0s/2m30.0s
+
+running (12m51.0s), 04/16 VUs, 206 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ↓ [ 100% ] 12/15 VUs  2m30s
+get_categories              [  14% ] 01/15 VUs  0m21.0s/2m30.0s
+
+running (12m52.0s), 03/16 VUs, 207 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ↓ [ 100% ] 12/15 VUs  2m30s
+get_categories              [  15% ] 01/15 VUs  0m22.0s/2m30.0s
+
+running (12m53.0s), 04/16 VUs, 207 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ↓ [ 100% ] 12/15 VUs  2m30s
+get_categories              [  15% ] 02/15 VUs  0m23.0s/2m30.0s
+
+running (12m54.0s), 04/16 VUs, 207 complete and 12 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ↓ [ 100% ] 12/15 VUs  2m30s
+get_categories              [  16% ] 02/15 VUs  0m24.0s/2m30.0s
+
+running (12m55.0s), 03/16 VUs, 207 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ↓ [ 100% ] 12/15 VUs  2m30s
+get_categories              [  17% ] 02/15 VUs  0m25.0s/2m30.0s
+
+running (12m56.0s), 03/16 VUs, 207 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ↓ [ 100% ] 12/15 VUs  2m30s
+get_categories              [  17% ] 02/15 VUs  0m26.0s/2m30.0s
+
+running (12m57.0s), 02/16 VUs, 208 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  18% ] 02/15 VUs  0m27.0s/2m30.0s
+
+running (12m58.0s), 02/16 VUs, 208 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  19% ] 02/15 VUs  0m28.0s/2m30.0s
+
+running (12m59.0s), 02/16 VUs, 208 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  19% ] 02/15 VUs  0m29.0s/2m30.0s
+
+running (13m00.0s), 02/16 VUs, 208 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  20% ] 02/15 VUs  0m30.0s/2m30.0s
+
+running (13m01.0s), 03/16 VUs, 209 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  21% ] 03/15 VUs  0m31.0s/2m30.0s
+
+running (13m02.0s), 03/16 VUs, 209 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  21% ] 03/15 VUs  0m32.0s/2m30.0s
+
+running (13m03.0s), 03/16 VUs, 209 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  22% ] 03/15 VUs  0m33.0s/2m30.0s
+
+running (13m04.0s), 03/16 VUs, 209 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  23% ] 03/15 VUs  0m34.0s/2m30.0s
+
+running (13m05.0s), 03/16 VUs, 209 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  23% ] 03/15 VUs  0m35.0s/2m30.0s
+
+running (13m06.0s), 03/16 VUs, 209 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  24% ] 03/15 VUs  0m36.0s/2m30.0s
+
+running (13m07.0s), 03/16 VUs, 209 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  25% ] 03/15 VUs  0m37.0s/2m30.0s
+
+running (13m08.0s), 04/16 VUs, 209 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  25% ] 04/15 VUs  0m38.0s/2m30.0s
+
+running (13m09.0s), 04/16 VUs, 209 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  26% ] 04/15 VUs  0m39.0s/2m30.0s
+
+running (13m10.0s), 04/16 VUs, 209 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  27% ] 04/15 VUs  0m40.0s/2m30.0s
+
+running (13m11.0s), 04/16 VUs, 209 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  27% ] 04/15 VUs  0m41.0s/2m30.0s
+
+running (13m12.0s), 04/16 VUs, 209 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  28% ] 04/15 VUs  0m42.0s/2m30.0s
+
+running (13m13.0s), 04/16 VUs, 209 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  29% ] 04/15 VUs  0m43.0s/2m30.0s
+
+running (13m14.0s), 04/16 VUs, 209 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  29% ] 04/15 VUs  0m44.0s/2m30.0s
+
+running (13m15.0s), 04/16 VUs, 209 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  30% ] 04/15 VUs  0m45.0s/2m30.0s
+
+running (13m16.0s), 05/16 VUs, 209 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  31% ] 05/15 VUs  0m46.0s/2m30.0s
+
+running (13m17.0s), 05/16 VUs, 209 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  31% ] 05/15 VUs  0m47.0s/2m30.0s
+
+running (13m18.0s), 05/16 VUs, 209 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  32% ] 05/15 VUs  0m48.0s/2m30.0s
+
+running (13m19.0s), 05/16 VUs, 209 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  33% ] 05/15 VUs  0m49.0s/2m30.0s
+
+running (13m20.0s), 05/16 VUs, 209 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  33% ] 05/15 VUs  0m50.0s/2m30.0s
+
+running (13m21.0s), 05/16 VUs, 209 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  34% ] 05/15 VUs  0m51.0s/2m30.0s
+
+running (13m22.0s), 05/16 VUs, 209 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  35% ] 05/15 VUs  0m52.0s/2m30.0s
+
+running (13m23.0s), 05/16 VUs, 209 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  35% ] 05/15 VUs  0m53.0s/2m30.0s
+
+running (13m24.0s), 05/16 VUs, 210 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  36% ] 05/15 VUs  0m54.0s/2m30.0s
+
+running (13m25.0s), 05/16 VUs, 210 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  37% ] 05/15 VUs  0m55.0s/2m30.0s
+
+running (13m26.0s), 05/16 VUs, 210 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  37% ] 05/15 VUs  0m56.0s/2m30.0s
+
+running (13m27.0s), 05/16 VUs, 210 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  38% ] 05/15 VUs  0m57.0s/2m30.0s
+
+running (13m28.0s), 05/16 VUs, 210 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  39% ] 05/15 VUs  0m58.0s/2m30.0s
+
+running (13m29.0s), 05/16 VUs, 210 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  39% ] 05/15 VUs  0m59.0s/2m30.0s
+
+running (13m30.0s), 05/16 VUs, 210 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  40% ] 05/15 VUs  1m00.0s/2m30.0s
+
+running (13m31.0s), 05/16 VUs, 211 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  41% ] 05/15 VUs  1m01.0s/2m30.0s
+
+running (13m32.0s), 05/16 VUs, 212 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  41% ] 05/15 VUs  1m02.0s/2m30.0s
+
+running (13m33.0s), 05/16 VUs, 212 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  42% ] 05/15 VUs  1m03.0s/2m30.0s
+
+running (13m34.0s), 05/16 VUs, 212 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  43% ] 05/15 VUs  1m04.0s/2m30.0s
+
+running (13m35.0s), 05/16 VUs, 212 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  43% ] 05/15 VUs  1m05.0s/2m30.0s
+
+running (13m36.0s), 05/16 VUs, 212 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  44% ] 05/15 VUs  1m06.0s/2m30.0s
+
+running (13m37.0s), 05/16 VUs, 212 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  45% ] 05/15 VUs  1m07.0s/2m30.0s
+
+running (13m38.0s), 05/16 VUs, 212 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  45% ] 05/15 VUs  1m08.0s/2m30.0s
+
+running (13m39.0s), 05/16 VUs, 213 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  46% ] 05/15 VUs  1m09.0s/2m30.0s
+
+running (13m40.0s), 05/16 VUs, 213 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  47% ] 05/15 VUs  1m10.0s/2m30.0s
+
+running (13m41.0s), 05/16 VUs, 213 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  47% ] 05/15 VUs  1m11.0s/2m30.0s
+
+running (13m42.0s), 05/16 VUs, 213 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  48% ] 05/15 VUs  1m12.0s/2m30.0s
+
+running (13m43.0s), 05/16 VUs, 213 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  49% ] 05/15 VUs  1m13.0s/2m30.0s
+
+running (13m44.0s), 05/16 VUs, 213 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  49% ] 05/15 VUs  1m14.0s/2m30.0s
+
+running (13m45.0s), 05/16 VUs, 213 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  50% ] 05/15 VUs  1m15.0s/2m30.0s
+
+running (13m46.0s), 05/16 VUs, 214 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  51% ] 05/15 VUs  1m16.0s/2m30.0s
+
+running (13m47.0s), 05/16 VUs, 214 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  51% ] 05/15 VUs  1m17.0s/2m30.0s
+
+running (13m48.0s), 05/16 VUs, 214 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  52% ] 05/15 VUs  1m18.0s/2m30.0s
+time="2026-03-12T14:34:03Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/categories\": dial tcp 172.20.150.69:80: connect: connection refused"
+time="2026-03-12T14:34:03Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/categories\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (13m49.0s), 06/16 VUs, 215 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  53% ] 06/15 VUs  1m19.0s/2m30.0s
+
+running (13m50.0s), 06/16 VUs, 216 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  53% ] 06/15 VUs  1m20.0s/2m30.0s
+
+running (13m51.0s), 06/16 VUs, 216 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  54% ] 06/15 VUs  1m21.0s/2m30.0s
+
+running (13m52.0s), 07/16 VUs, 216 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  55% ] 07/15 VUs  1m22.0s/2m30.0s
+
+running (13m53.0s), 07/16 VUs, 216 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  55% ] 07/15 VUs  1m23.0s/2m30.0s
+
+running (13m54.0s), 07/16 VUs, 217 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  56% ] 07/15 VUs  1m24.0s/2m30.0s
+
+running (13m55.0s), 08/16 VUs, 217 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  57% ] 08/15 VUs  1m25.0s/2m30.0s
+
+running (13m56.0s), 08/16 VUs, 217 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  57% ] 08/15 VUs  1m26.0s/2m30.0s
+
+running (13m57.0s), 08/16 VUs, 217 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  58% ] 08/15 VUs  1m27.0s/2m30.0s
+
+running (13m58.0s), 09/16 VUs, 217 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  59% ] 09/15 VUs  1m28.0s/2m30.0s
+
+running (13m59.0s), 09/16 VUs, 217 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  59% ] 09/15 VUs  1m29.0s/2m30.0s
+
+running (14m00.0s), 09/16 VUs, 217 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  60% ] 09/15 VUs  1m30.0s/2m30.0s
+
+running (14m01.0s), 10/16 VUs, 217 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  61% ] 10/15 VUs  1m31.0s/2m30.0s
+
+running (14m02.0s), 10/16 VUs, 219 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  61% ] 10/15 VUs  1m32.0s/2m30.0s
+
+running (14m03.0s), 10/16 VUs, 219 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  62% ] 10/15 VUs  1m33.0s/2m30.0s
+time="2026-03-12T14:34:18Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/categories\": dial tcp 172.20.150.69:80: connect: connection refused"
+time="2026-03-12T14:34:18Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/categories\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (14m04.0s), 11/16 VUs, 220 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  63% ] 11/15 VUs  1m34.0s/2m30.0s
+time="2026-03-12T14:34:19Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/categories\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (14m05.0s), 11/16 VUs, 222 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  63% ] 11/15 VUs  1m35.0s/2m30.0s
+
+running (14m06.0s), 11/16 VUs, 222 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  64% ] 11/15 VUs  1m36.0s/2m30.0s
+
+running (14m07.0s), 12/16 VUs, 222 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  65% ] 12/15 VUs  1m37.0s/2m30.0s
+
+running (14m08.0s), 12/16 VUs, 222 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  65% ] 12/15 VUs  1m38.0s/2m30.0s
+
+running (14m09.0s), 12/16 VUs, 223 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  66% ] 12/15 VUs  1m39.0s/2m30.0s
+
+running (14m10.0s), 13/16 VUs, 223 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  67% ] 13/15 VUs  1m40.0s/2m30.0s
+
+running (14m11.0s), 13/16 VUs, 223 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  67% ] 13/15 VUs  1m41.0s/2m30.0s
+
+running (14m12.0s), 13/16 VUs, 223 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  68% ] 13/15 VUs  1m42.0s/2m30.0s
+
+running (14m13.0s), 14/16 VUs, 223 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  69% ] 14/15 VUs  1m43.0s/2m30.0s
+
+running (14m14.0s), 14/16 VUs, 223 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  69% ] 14/15 VUs  1m44.0s/2m30.0s
+
+running (14m15.0s), 14/16 VUs, 223 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  70% ] 14/15 VUs  1m45.0s/2m30.0s
+
+running (14m16.0s), 15/16 VUs, 223 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  71% ] 15/15 VUs  1m46.0s/2m30.0s
+
+running (14m17.0s), 15/16 VUs, 224 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  71% ] 15/15 VUs  1m47.0s/2m30.0s
+
+running (14m18.0s), 15/16 VUs, 224 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  72% ] 15/15 VUs  1m48.0s/2m30.0s
+
+running (14m19.0s), 15/16 VUs, 224 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  73% ] 15/15 VUs  1m49.0s/2m30.0s
+
+running (14m20.0s), 15/16 VUs, 225 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  73% ] 15/15 VUs  1m50.0s/2m30.0s
+
+running (14m21.0s), 15/16 VUs, 225 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  74% ] 15/15 VUs  1m51.0s/2m30.0s
+
+running (14m22.0s), 15/16 VUs, 226 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  75% ] 15/15 VUs  1m52.0s/2m30.0s
+
+running (14m23.0s), 15/16 VUs, 226 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  75% ] 15/15 VUs  1m53.0s/2m30.0s
+
+running (14m24.0s), 15/16 VUs, 226 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  76% ] 15/15 VUs  1m54.0s/2m30.0s
+
+running (14m25.0s), 15/16 VUs, 228 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  77% ] 15/15 VUs  1m55.0s/2m30.0s
+
+running (14m26.0s), 15/16 VUs, 228 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  77% ] 15/15 VUs  1m56.0s/2m30.0s
+
+running (14m27.0s), 15/16 VUs, 228 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  78% ] 15/15 VUs  1m57.0s/2m30.0s
+
+running (14m28.0s), 15/16 VUs, 229 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  79% ] 15/15 VUs  1m58.0s/2m30.0s
+
+running (14m29.0s), 15/16 VUs, 229 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  79% ] 15/15 VUs  1m59.0s/2m30.0s
+
+running (14m30.0s), 15/16 VUs, 229 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  80% ] 15/15 VUs  2m00.0s/2m30.0s
+
+running (14m31.0s), 15/16 VUs, 230 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  81% ] 15/15 VUs  2m01.0s/2m30.0s
+
+running (14m32.0s), 15/16 VUs, 231 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  81% ] 15/15 VUs  2m02.0s/2m30.0s
+
+running (14m33.0s), 15/16 VUs, 232 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  82% ] 15/15 VUs  2m03.0s/2m30.0s
+
+running (14m34.0s), 15/16 VUs, 232 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  83% ] 15/15 VUs  2m04.0s/2m30.0s
+
+running (14m35.0s), 15/16 VUs, 232 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  83% ] 15/15 VUs  2m05.0s/2m30.0s
+
+running (14m36.0s), 15/16 VUs, 233 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  84% ] 15/15 VUs  2m06.0s/2m30.0s
+
+running (14m37.0s), 15/16 VUs, 234 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  85% ] 15/15 VUs  2m07.0s/2m30.0s
+
+running (14m38.0s), 15/16 VUs, 234 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  85% ] 15/15 VUs  2m08.0s/2m30.0s
+
+running (14m39.0s), 15/16 VUs, 234 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  86% ] 15/15 VUs  2m09.0s/2m30.0s
+
+running (14m40.0s), 15/16 VUs, 236 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  87% ] 15/15 VUs  2m10.0s/2m30.0s
+
+running (14m41.0s), 15/16 VUs, 236 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  87% ] 15/15 VUs  2m11.0s/2m30.0s
+
+running (14m42.0s), 15/16 VUs, 236 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  88% ] 15/15 VUs  2m12.0s/2m30.0s
+
+running (14m43.0s), 15/16 VUs, 237 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  89% ] 15/15 VUs  2m13.0s/2m30.0s
+
+running (14m44.0s), 15/16 VUs, 237 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  89% ] 15/15 VUs  2m14.0s/2m30.0s
+
+running (14m45.0s), 15/16 VUs, 237 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  90% ] 15/15 VUs  2m15.0s/2m30.0s
+
+running (14m46.0s), 15/16 VUs, 238 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  91% ] 15/15 VUs  2m16.0s/2m30.0s
+
+running (14m47.0s), 15/16 VUs, 239 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  91% ] 15/15 VUs  2m17.0s/2m30.0s
+
+running (14m48.0s), 15/16 VUs, 239 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  92% ] 15/15 VUs  2m18.0s/2m30.0s
+
+running (14m49.0s), 15/16 VUs, 239 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  93% ] 15/15 VUs  2m19.0s/2m30.0s
+
+running (14m50.0s), 15/16 VUs, 239 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  93% ] 15/15 VUs  2m20.0s/2m30.0s
+
+running (14m51.0s), 15/16 VUs, 240 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  94% ] 15/15 VUs  2m21.0s/2m30.0s
+
+running (14m52.0s), 15/16 VUs, 240 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  95% ] 15/15 VUs  2m22.0s/2m30.0s
+
+running (14m53.0s), 15/16 VUs, 241 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  95% ] 15/15 VUs  2m23.0s/2m30.0s
+
+running (14m54.0s), 15/16 VUs, 241 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  96% ] 15/15 VUs  2m24.0s/2m30.0s
+
+running (14m55.0s), 15/16 VUs, 242 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  97% ] 15/15 VUs  2m25.0s/2m30.0s
+
+running (14m56.0s), 14/16 VUs, 243 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  97% ] 14/15 VUs  2m26.0s/2m30.0s
+
+running (14m57.0s), 14/16 VUs, 243 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  98% ] 14/15 VUs  2m27.0s/2m30.0s
+
+running (14m58.0s), 14/16 VUs, 243 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  99% ] 14/15 VUs  2m28.0s/2m30.0s
+
+running (14m59.0s), 13/16 VUs, 244 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [  99% ] 13/15 VUs  2m29.0s/2m30.0s
+
+running (15m00.0s), 13/16 VUs, 244 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories              [ 100% ] 13/15 VUs  2m30.0s/2m30.0s
+
+running (15m01.0s), 13/16 VUs, 244 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories            ↓ [ 100% ] 13/15 VUs  2m30s
+
+running (15m02.0s), 12/16 VUs, 245 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories            ↓ [ 100% ] 13/15 VUs  2m30s
+
+running (15m03.0s), 10/16 VUs, 247 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories            ↓ [ 100% ] 13/15 VUs  2m30s
+
+running (15m04.0s), 10/16 VUs, 247 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories            ↓ [ 100% ] 13/15 VUs  2m30s
+
+running (15m05.0s), 10/16 VUs, 247 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories            ↓ [ 100% ] 13/15 VUs  2m30s
+
+running (15m06.0s), 09/16 VUs, 248 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories            ↓ [ 100% ] 13/15 VUs  2m30s
+
+running (15m07.0s), 09/16 VUs, 248 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories            ↓ [ 100% ] 13/15 VUs  2m30s
+
+running (15m08.0s), 08/16 VUs, 249 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories            ↓ [ 100% ] 13/15 VUs  2m30s
+
+running (15m09.0s), 08/16 VUs, 249 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories            ↓ [ 100% ] 13/15 VUs  2m30s
+
+running (15m10.0s), 07/16 VUs, 250 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories            ↓ [ 100% ] 13/15 VUs  2m30s
+
+running (15m11.0s), 06/16 VUs, 251 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories            ↓ [ 100% ] 13/15 VUs  2m30s
+
+running (15m12.0s), 06/16 VUs, 251 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories            ↓ [ 100% ] 13/15 VUs  2m30s
+
+running (15m13.0s), 06/16 VUs, 251 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories            ↓ [ 100% ] 13/15 VUs  2m30s
+
+running (15m14.0s), 05/16 VUs, 252 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories            ↓ [ 100% ] 13/15 VUs  2m30s
+
+running (15m15.0s), 05/16 VUs, 252 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories            ↓ [ 100% ] 13/15 VUs  2m30s
+
+running (15m16.0s), 05/16 VUs, 252 complete and 13 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories            ↓ [ 100% ] 13/15 VUs  2m30s
+
+running (15m17.0s), 04/16 VUs, 252 complete and 14 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories            ↓ [ 100% ] 13/15 VUs  2m30s
+
+running (15m18.0s), 03/16 VUs, 253 complete and 14 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories            ↓ [ 100% ] 13/15 VUs  2m30s
+
+running (15m19.0s), 03/16 VUs, 253 complete and 14 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories            ↓ [ 100% ] 13/15 VUs  2m30s
+
+running (15m20.0s), 03/16 VUs, 253 complete and 14 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories            ↓ [ 100% ] 13/15 VUs  2m30s
+
+running (15m21.0s), 02/16 VUs, 254 complete and 14 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories            ↓ [ 100% ] 13/15 VUs  2m30s
+
+running (15m22.0s), 02/16 VUs, 254 complete and 14 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories            ↓ [ 100% ] 13/15 VUs  2m30s
+
+running (15m23.0s), 01/16 VUs, 255 complete and 14 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories            ↓ [ 100% ] 13/15 VUs  2m30s
+
+running (15m24.0s), 01/16 VUs, 255 complete and 14 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories            ↓ [ 100% ] 13/15 VUs  2m30s
+
+running (15m25.0s), 01/16 VUs, 255 complete and 14 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories            ↓ [ 100% ] 13/15 VUs  2m30s
+
+
+  █ THRESHOLDS 
+
+    http_req_failed
+    ✗ 'rate<0.05' rate=100.00%
+
+
+  █ TOTAL RESULTS 
+
+    checks_total.......: 217     0.234584/s
+    checks_succeeded...: 0.00%   0 out of 217
+    checks_failed......: 100.00% 217 out of 217
+
+    ✗ full_text_search status 200
+      ↳  0% — ✓ 0 / ✗ 28
+    ✗ filtered_sorted_paginated status 200
+      ↳  0% — ✓ 0 / ✗ 55
+    ✗ multi_field_search status 200
+      ↳  0% — ✓ 0 / ✗ 51
+    ✗ autocomplete status 200
+      ↳  0% — ✓ 0 / ✗ 34
+    ✗ get_categories status 200
+      ↳  0% — ✓ 0 / ✗ 49
+
+    CUSTOM
+    autocomplete_duration................: min=0s       avg=32.65s med=30s    p(90)=1m0s   p(95)=1m0s   p(99)=1m0s   max=1m0s  
+    errors...............................: 217     0.234584/s
+    filtered_sorted_paginated_duration...: min=0s       avg=22.91s med=30s    p(90)=30.01s p(95)=30.02s p(99)=43.88s max=1m0s  
+    full_text_search_duration............: min=0s       avg=42.86s med=59.99s p(90)=1m0s   p(95)=1m0s   p(99)=1m0s   max=1m0s  
+    get_categories_duration..............: min=0s       avg=26.94s med=30s    p(90)=30.01s p(95)=30.01s p(99)=30.02s max=30.04s
+    multi_field_search_duration..........: min=0s       avg=25.3s  med=30s    p(90)=30.01s p(95)=30.01s p(99)=30.01s max=30.01s
+
+    HTTP
+    http_req_duration....................: min=0s       avg=28.73s med=30s    p(90)=59.99s p(95)=1m0s   p(99)=1m0s   max=1m0s  
+    http_req_failed......................: 100.00% 260 out of 260
+    http_reqs............................: 260     0.281069/s
+
+    EXECUTION
+    iteration_duration...................: min=500.56ms avg=29.44s med=31s    p(90)=1m0s   p(95)=1m1s   p(99)=1m1s   max=1m1s  
+    iterations...........................: 256     0.276745/s
+    vus..................................: 1       min=1          max=16
+    vus_max..............................: 16      min=16         max=16
+
+    NETWORK
+    data_received........................: 66 kB   71 B/s
+    data_sent............................: 29 kB   31 B/s
+
+
+
+
+running (15m25.0s), 00/16 VUs, 256 complete and 14 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/15 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/15 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/15 VUs  2m30s
+autocomplete              ✓ [ 100% ] 01/15 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/15 VUs  2m30s
+get_categories            ✓ [ 100% ] 00/15 VUs  2m30s
+time="2026-03-12T14:35:40Z" level=error msg="thresholds on metrics 'http_req_failed' have been crossed"

--- a/benchmark-results-mysql-baseline/benchmark-results.log
+++ b/benchmark-results-mysql-baseline/benchmark-results.log
@@ -1,0 +1,7686 @@
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+
+     execution: local
+        script: /scripts/mysql-baseline.js
+        output: -
+
+     scenarios: (100.00%) 6 scenarios, 51 max VUs, 15m30s max duration (incl. graceful stop):
+              * full_text_search: Up to 50 looping VUs for 2m30s over 6 stages (gracefulRampDown: 30s, exec: fullTextSearch, gracefulStop: 30s)
+              * filtered_sorted_paginated: Up to 50 looping VUs for 2m30s over 6 stages (gracefulRampDown: 30s, exec: filteredSortedPaginated, startTime: 2m30s, gracefulStop: 30s)
+              * multi_field_search: Up to 50 looping VUs for 2m30s over 6 stages (gracefulRampDown: 30s, exec: multiFieldSearch, startTime: 5m0s, gracefulStop: 30s)
+              * autocomplete: Up to 50 looping VUs for 2m30s over 6 stages (gracefulRampDown: 30s, exec: autocomplete, startTime: 7m30s, gracefulStop: 30s)
+              * get_by_id: Up to 50 looping VUs for 2m30s over 6 stages (gracefulRampDown: 30s, exec: getById, startTime: 10m0s, gracefulStop: 30s)
+              * get_categories: Up to 50 looping VUs for 2m30s over 6 stages (gracefulRampDown: 30s, exec: getCategories, startTime: 12m30s, gracefulStop: 30s)
+
+
+running (00m01.0s), 01/51 VUs, 0 complete and 0 interrupted iterations
+full_text_search            [   1% ] 01/50 VUs  0m01.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    2m29.0s
+multi_field_search        • [   0% ] waiting    4m59.0s
+autocomplete              • [   0% ] waiting    7m29.0s
+get_by_id                 • [   0% ] waiting    09m59.0s
+get_categories            • [   0% ] waiting    12m29.0s
+
+running (00m02.0s), 01/51 VUs, 0 complete and 0 interrupted iterations
+full_text_search            [   1% ] 01/50 VUs  0m02.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    2m28.0s
+multi_field_search        • [   0% ] waiting    4m58.0s
+autocomplete              • [   0% ] waiting    7m28.0s
+get_by_id                 • [   0% ] waiting    09m58.0s
+get_categories            • [   0% ] waiting    12m28.0s
+
+running (00m03.0s), 01/51 VUs, 0 complete and 0 interrupted iterations
+full_text_search            [   2% ] 01/50 VUs  0m03.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    2m27.0s
+multi_field_search        • [   0% ] waiting    4m57.0s
+autocomplete              • [   0% ] waiting    7m27.0s
+get_by_id                 • [   0% ] waiting    09m57.0s
+get_categories            • [   0% ] waiting    12m27.0s
+
+running (00m04.0s), 01/51 VUs, 0 complete and 0 interrupted iterations
+full_text_search            [   3% ] 01/50 VUs  0m04.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    2m26.0s
+multi_field_search        • [   0% ] waiting    4m56.0s
+autocomplete              • [   0% ] waiting    7m26.0s
+get_by_id                 • [   0% ] waiting    09m56.0s
+get_categories            • [   0% ] waiting    12m26.0s
+
+running (00m05.0s), 01/51 VUs, 0 complete and 0 interrupted iterations
+full_text_search            [   3% ] 01/50 VUs  0m05.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    2m25.0s
+multi_field_search        • [   0% ] waiting    4m55.0s
+autocomplete              • [   0% ] waiting    7m25.0s
+get_by_id                 • [   0% ] waiting    09m55.0s
+get_categories            • [   0% ] waiting    12m25.0s
+
+running (00m06.0s), 01/51 VUs, 0 complete and 0 interrupted iterations
+full_text_search            [   4% ] 01/50 VUs  0m06.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    2m24.0s
+multi_field_search        • [   0% ] waiting    4m54.0s
+autocomplete              • [   0% ] waiting    7m24.0s
+get_by_id                 • [   0% ] waiting    09m54.0s
+get_categories            • [   0% ] waiting    12m24.0s
+
+running (00m07.0s), 01/51 VUs, 0 complete and 0 interrupted iterations
+full_text_search            [   5% ] 01/50 VUs  0m07.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    2m23.0s
+multi_field_search        • [   0% ] waiting    4m53.0s
+autocomplete              • [   0% ] waiting    7m23.0s
+get_by_id                 • [   0% ] waiting    09m53.0s
+get_categories            • [   0% ] waiting    12m23.0s
+
+running (00m08.0s), 01/51 VUs, 0 complete and 0 interrupted iterations
+full_text_search            [   5% ] 01/50 VUs  0m08.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    2m22.0s
+multi_field_search        • [   0% ] waiting    4m52.0s
+autocomplete              • [   0% ] waiting    7m22.0s
+get_by_id                 • [   0% ] waiting    09m52.0s
+get_categories            • [   0% ] waiting    12m22.0s
+
+running (00m09.0s), 01/51 VUs, 0 complete and 0 interrupted iterations
+full_text_search            [   6% ] 01/50 VUs  0m09.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    2m21.0s
+multi_field_search        • [   0% ] waiting    4m51.0s
+autocomplete              • [   0% ] waiting    7m21.0s
+get_by_id                 • [   0% ] waiting    09m51.0s
+get_categories            • [   0% ] waiting    12m21.0s
+
+running (00m10.0s), 01/51 VUs, 0 complete and 0 interrupted iterations
+full_text_search            [   7% ] 01/50 VUs  0m10.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    2m20.0s
+multi_field_search        • [   0% ] waiting    4m50.0s
+autocomplete              • [   0% ] waiting    7m20.0s
+get_by_id                 • [   0% ] waiting    09m50.0s
+get_categories            • [   0% ] waiting    12m20.0s
+
+running (00m11.0s), 01/51 VUs, 0 complete and 0 interrupted iterations
+full_text_search            [   7% ] 01/50 VUs  0m11.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    2m19.0s
+multi_field_search        • [   0% ] waiting    4m49.0s
+autocomplete              • [   0% ] waiting    7m19.0s
+get_by_id                 • [   0% ] waiting    09m49.0s
+get_categories            • [   0% ] waiting    12m19.0s
+
+running (00m12.0s), 01/51 VUs, 0 complete and 0 interrupted iterations
+full_text_search            [   8% ] 01/50 VUs  0m12.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    2m18.0s
+multi_field_search        • [   0% ] waiting    4m48.0s
+autocomplete              • [   0% ] waiting    7m18.0s
+get_by_id                 • [   0% ] waiting    09m48.0s
+get_categories            • [   0% ] waiting    12m18.0s
+
+running (00m13.0s), 01/51 VUs, 0 complete and 0 interrupted iterations
+full_text_search            [   9% ] 01/50 VUs  0m13.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    2m17.0s
+multi_field_search        • [   0% ] waiting    4m47.0s
+autocomplete              • [   0% ] waiting    7m17.0s
+get_by_id                 • [   0% ] waiting    09m47.0s
+get_categories            • [   0% ] waiting    12m17.0s
+
+running (00m14.0s), 01/51 VUs, 0 complete and 0 interrupted iterations
+full_text_search            [   9% ] 01/50 VUs  0m14.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    2m16.0s
+multi_field_search        • [   0% ] waiting    4m46.0s
+autocomplete              • [   0% ] waiting    7m16.0s
+get_by_id                 • [   0% ] waiting    09m46.0s
+get_categories            • [   0% ] waiting    12m16.0s
+
+running (00m15.0s), 01/51 VUs, 0 complete and 0 interrupted iterations
+full_text_search            [  10% ] 01/50 VUs  0m15.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    2m15.0s
+multi_field_search        • [   0% ] waiting    4m45.0s
+autocomplete              • [   0% ] waiting    7m15.0s
+get_by_id                 • [   0% ] waiting    09m45.0s
+get_categories            • [   0% ] waiting    12m15.0s
+
+running (00m16.0s), 01/51 VUs, 0 complete and 0 interrupted iterations
+full_text_search            [  11% ] 01/50 VUs  0m16.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    2m14.0s
+multi_field_search        • [   0% ] waiting    4m44.0s
+autocomplete              • [   0% ] waiting    7m14.0s
+get_by_id                 • [   0% ] waiting    09m44.0s
+get_categories            • [   0% ] waiting    12m14.0s
+
+running (00m17.0s), 01/51 VUs, 0 complete and 0 interrupted iterations
+full_text_search            [  11% ] 01/50 VUs  0m17.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    2m13.0s
+multi_field_search        • [   0% ] waiting    4m43.0s
+autocomplete              • [   0% ] waiting    7m13.0s
+get_by_id                 • [   0% ] waiting    09m43.0s
+get_categories            • [   0% ] waiting    12m13.0s
+
+running (00m18.0s), 01/51 VUs, 0 complete and 0 interrupted iterations
+full_text_search            [  12% ] 01/50 VUs  0m18.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    2m12.0s
+multi_field_search        • [   0% ] waiting    4m42.0s
+autocomplete              • [   0% ] waiting    7m12.0s
+get_by_id                 • [   0% ] waiting    09m42.0s
+get_categories            • [   0% ] waiting    12m12.0s
+time="2026-03-12T13:18:33Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=canvas%20bag&size=20&page=0\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (00m19.0s), 02/51 VUs, 1 complete and 0 interrupted iterations
+full_text_search            [  13% ] 02/50 VUs  0m19.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    2m11.0s
+multi_field_search        • [   0% ] waiting    4m41.0s
+autocomplete              • [   0% ] waiting    7m11.0s
+get_by_id                 • [   0% ] waiting    09m41.0s
+get_categories            • [   0% ] waiting    12m11.0s
+
+running (00m20.0s), 02/51 VUs, 1 complete and 0 interrupted iterations
+full_text_search            [  13% ] 02/50 VUs  0m20.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    2m10.0s
+multi_field_search        • [   0% ] waiting    4m40.0s
+autocomplete              • [   0% ] waiting    7m10.0s
+get_by_id                 • [   0% ] waiting    09m40.0s
+get_categories            • [   0% ] waiting    12m10.0s
+
+running (00m21.0s), 02/51 VUs, 1 complete and 0 interrupted iterations
+full_text_search            [  14% ] 02/50 VUs  0m21.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    2m09.0s
+multi_field_search        • [   0% ] waiting    4m39.0s
+autocomplete              • [   0% ] waiting    7m09.0s
+get_by_id                 • [   0% ] waiting    09m39.0s
+get_categories            • [   0% ] waiting    12m09.0s
+
+running (00m22.0s), 03/51 VUs, 1 complete and 0 interrupted iterations
+full_text_search            [  15% ] 03/50 VUs  0m22.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    2m08.0s
+multi_field_search        • [   0% ] waiting    4m38.0s
+autocomplete              • [   0% ] waiting    7m08.0s
+get_by_id                 • [   0% ] waiting    09m38.0s
+get_categories            • [   0% ] waiting    12m08.0s
+
+running (00m23.0s), 03/51 VUs, 1 complete and 0 interrupted iterations
+full_text_search            [  15% ] 03/50 VUs  0m23.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    2m07.0s
+multi_field_search        • [   0% ] waiting    4m37.0s
+autocomplete              • [   0% ] waiting    7m07.0s
+get_by_id                 • [   0% ] waiting    09m37.0s
+get_categories            • [   0% ] waiting    12m07.0s
+
+running (00m24.0s), 03/51 VUs, 1 complete and 0 interrupted iterations
+full_text_search            [  16% ] 03/50 VUs  0m24.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    2m06.0s
+multi_field_search        • [   0% ] waiting    4m36.0s
+autocomplete              • [   0% ] waiting    7m06.0s
+get_by_id                 • [   0% ] waiting    09m36.0s
+get_categories            • [   0% ] waiting    12m06.0s
+
+running (00m25.0s), 03/51 VUs, 1 complete and 0 interrupted iterations
+full_text_search            [  17% ] 03/50 VUs  0m25.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    2m05.0s
+multi_field_search        • [   0% ] waiting    4m35.0s
+autocomplete              • [   0% ] waiting    7m05.0s
+get_by_id                 • [   0% ] waiting    09m35.0s
+get_categories            • [   0% ] waiting    12m05.0s
+
+running (00m26.0s), 04/51 VUs, 1 complete and 0 interrupted iterations
+full_text_search            [  17% ] 04/50 VUs  0m26.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    2m04.0s
+multi_field_search        • [   0% ] waiting    4m34.0s
+autocomplete              • [   0% ] waiting    7m04.0s
+get_by_id                 • [   0% ] waiting    09m34.0s
+get_categories            • [   0% ] waiting    12m04.0s
+
+running (00m27.0s), 04/51 VUs, 1 complete and 0 interrupted iterations
+full_text_search            [  18% ] 04/50 VUs  0m27.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    2m03.0s
+multi_field_search        • [   0% ] waiting    4m33.0s
+autocomplete              • [   0% ] waiting    7m03.0s
+get_by_id                 • [   0% ] waiting    09m33.0s
+get_categories            • [   0% ] waiting    12m03.0s
+
+running (00m28.0s), 04/51 VUs, 1 complete and 0 interrupted iterations
+full_text_search            [  19% ] 04/50 VUs  0m28.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    2m02.0s
+multi_field_search        • [   0% ] waiting    4m32.0s
+autocomplete              • [   0% ] waiting    7m02.0s
+get_by_id                 • [   0% ] waiting    09m32.0s
+get_categories            • [   0% ] waiting    12m02.0s
+
+running (00m29.0s), 05/51 VUs, 1 complete and 0 interrupted iterations
+full_text_search            [  19% ] 05/50 VUs  0m29.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    2m01.0s
+multi_field_search        • [   0% ] waiting    4m31.0s
+autocomplete              • [   0% ] waiting    7m01.0s
+get_by_id                 • [   0% ] waiting    09m31.0s
+get_categories            • [   0% ] waiting    12m01.0s
+
+running (00m30.0s), 05/51 VUs, 1 complete and 0 interrupted iterations
+full_text_search            [  20% ] 05/50 VUs  0m30.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    2m00.0s
+multi_field_search        • [   0% ] waiting    4m30.0s
+autocomplete              • [   0% ] waiting    7m00.0s
+get_by_id                 • [   0% ] waiting    09m30.0s
+get_categories            • [   0% ] waiting    12m00.0s
+
+running (00m31.0s), 05/51 VUs, 1 complete and 0 interrupted iterations
+full_text_search            [  21% ] 05/50 VUs  0m31.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m59.0s
+multi_field_search        • [   0% ] waiting    4m29.0s
+autocomplete              • [   0% ] waiting    6m59.0s
+get_by_id                 • [   0% ] waiting    09m29.0s
+get_categories            • [   0% ] waiting    11m59.0s
+
+running (00m32.0s), 06/51 VUs, 1 complete and 0 interrupted iterations
+full_text_search            [  21% ] 06/50 VUs  0m32.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m58.0s
+multi_field_search        • [   0% ] waiting    4m28.0s
+autocomplete              • [   0% ] waiting    6m58.0s
+get_by_id                 • [   0% ] waiting    09m28.0s
+get_categories            • [   0% ] waiting    11m58.0s
+
+running (00m33.0s), 06/51 VUs, 1 complete and 0 interrupted iterations
+full_text_search            [  22% ] 06/50 VUs  0m33.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m57.0s
+multi_field_search        • [   0% ] waiting    4m27.0s
+autocomplete              • [   0% ] waiting    6m57.0s
+get_by_id                 • [   0% ] waiting    09m27.0s
+get_categories            • [   0% ] waiting    11m57.0s
+
+running (00m34.0s), 06/51 VUs, 1 complete and 0 interrupted iterations
+full_text_search            [  23% ] 06/50 VUs  0m34.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m56.0s
+multi_field_search        • [   0% ] waiting    4m26.0s
+autocomplete              • [   0% ] waiting    6m56.0s
+get_by_id                 • [   0% ] waiting    09m26.0s
+get_categories            • [   0% ] waiting    11m56.0s
+
+running (00m35.0s), 06/51 VUs, 1 complete and 0 interrupted iterations
+full_text_search            [  23% ] 06/50 VUs  0m35.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m55.0s
+multi_field_search        • [   0% ] waiting    4m25.0s
+autocomplete              • [   0% ] waiting    6m55.0s
+get_by_id                 • [   0% ] waiting    09m25.0s
+get_categories            • [   0% ] waiting    11m55.0s
+time="2026-03-12T13:18:50Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=marble%20table&size=20&page=4\": dial tcp 172.20.150.69:80: connect: connection refused"
+time="2026-03-12T13:18:50Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=canvas%20bag&size=20&page=0\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (00m36.0s), 07/51 VUs, 2 complete and 0 interrupted iterations
+full_text_search            [  24% ] 07/50 VUs  0m36.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m54.0s
+multi_field_search        • [   0% ] waiting    4m24.0s
+autocomplete              • [   0% ] waiting    6m54.0s
+get_by_id                 • [   0% ] waiting    09m24.0s
+get_categories            • [   0% ] waiting    11m54.0s
+
+running (00m37.0s), 07/51 VUs, 3 complete and 0 interrupted iterations
+full_text_search            [  25% ] 07/50 VUs  0m37.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m53.0s
+multi_field_search        • [   0% ] waiting    4m23.0s
+autocomplete              • [   0% ] waiting    6m53.0s
+get_by_id                 • [   0% ] waiting    09m23.0s
+get_categories            • [   0% ] waiting    11m53.0s
+
+running (00m38.0s), 07/51 VUs, 3 complete and 0 interrupted iterations
+full_text_search            [  25% ] 07/50 VUs  0m38.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m52.0s
+multi_field_search        • [   0% ] waiting    4m22.0s
+autocomplete              • [   0% ] waiting    6m52.0s
+get_by_id                 • [   0% ] waiting    09m22.0s
+get_categories            • [   0% ] waiting    11m52.0s
+
+running (00m39.0s), 08/51 VUs, 3 complete and 0 interrupted iterations
+full_text_search            [  26% ] 08/50 VUs  0m39.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m51.0s
+multi_field_search        • [   0% ] waiting    4m21.0s
+autocomplete              • [   0% ] waiting    6m51.0s
+get_by_id                 • [   0% ] waiting    09m21.0s
+get_categories            • [   0% ] waiting    11m51.0s
+
+running (00m40.0s), 08/51 VUs, 3 complete and 0 interrupted iterations
+full_text_search            [  27% ] 08/50 VUs  0m40.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m50.0s
+multi_field_search        • [   0% ] waiting    4m20.0s
+autocomplete              • [   0% ] waiting    6m50.0s
+get_by_id                 • [   0% ] waiting    09m20.0s
+get_categories            • [   0% ] waiting    11m50.0s
+
+running (00m41.0s), 08/51 VUs, 3 complete and 0 interrupted iterations
+full_text_search            [  27% ] 08/50 VUs  0m41.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m49.0s
+multi_field_search        • [   0% ] waiting    4m19.0s
+autocomplete              • [   0% ] waiting    6m49.0s
+get_by_id                 • [   0% ] waiting    09m19.0s
+get_categories            • [   0% ] waiting    11m49.0s
+time="2026-03-12T13:18:57Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=wool%20blanket&size=20&page=4\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (00m42.0s), 09/51 VUs, 3 complete and 0 interrupted iterations
+full_text_search            [  28% ] 09/50 VUs  0m42.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m48.0s
+multi_field_search        • [   0% ] waiting    4m18.0s
+autocomplete              • [   0% ] waiting    6m48.0s
+get_by_id                 • [   0% ] waiting    09m18.0s
+get_categories            • [   0% ] waiting    11m48.0s
+time="2026-03-12T13:18:57Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=silk%20scarf&size=20&page=1\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (00m43.0s), 09/51 VUs, 5 complete and 0 interrupted iterations
+full_text_search            [  29% ] 09/50 VUs  0m43.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m47.0s
+multi_field_search        • [   0% ] waiting    4m17.0s
+autocomplete              • [   0% ] waiting    6m47.0s
+get_by_id                 • [   0% ] waiting    09m17.0s
+get_categories            • [   0% ] waiting    11m47.0s
+
+running (00m44.0s), 09/51 VUs, 5 complete and 0 interrupted iterations
+full_text_search            [  29% ] 09/50 VUs  0m44.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m46.0s
+multi_field_search        • [   0% ] waiting    4m16.0s
+autocomplete              • [   0% ] waiting    6m46.0s
+get_by_id                 • [   0% ] waiting    09m16.0s
+get_categories            • [   0% ] waiting    11m46.0s
+
+running (00m45.0s), 09/51 VUs, 5 complete and 0 interrupted iterations
+full_text_search            [  30% ] 09/50 VUs  0m45.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m45.0s
+multi_field_search        • [   0% ] waiting    4m15.0s
+autocomplete              • [   0% ] waiting    6m45.0s
+get_by_id                 • [   0% ] waiting    09m15.0s
+get_categories            • [   0% ] waiting    11m45.0s
+time="2026-03-12T13:19:00Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=titanium%20watch&size=20&page=4\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (00m46.0s), 10/51 VUs, 6 complete and 0 interrupted iterations
+full_text_search            [  31% ] 10/50 VUs  0m46.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m44.0s
+multi_field_search        • [   0% ] waiting    4m14.0s
+autocomplete              • [   0% ] waiting    6m44.0s
+get_by_id                 • [   0% ] waiting    09m14.0s
+get_categories            • [   0% ] waiting    11m44.0s
+
+running (00m47.0s), 10/51 VUs, 6 complete and 0 interrupted iterations
+full_text_search            [  31% ] 10/50 VUs  0m47.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m43.0s
+multi_field_search        • [   0% ] waiting    4m13.0s
+autocomplete              • [   0% ] waiting    6m43.0s
+get_by_id                 • [   0% ] waiting    09m13.0s
+get_categories            • [   0% ] waiting    11m43.0s
+
+running (00m48.0s), 10/51 VUs, 6 complete and 0 interrupted iterations
+full_text_search            [  32% ] 10/50 VUs  0m48.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m42.0s
+multi_field_search        • [   0% ] waiting    4m12.0s
+autocomplete              • [   0% ] waiting    6m42.0s
+get_by_id                 • [   0% ] waiting    09m12.0s
+get_categories            • [   0% ] waiting    11m42.0s
+
+running (00m49.0s), 10/51 VUs, 6 complete and 0 interrupted iterations
+full_text_search            [  33% ] 10/50 VUs  0m49.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m41.0s
+multi_field_search        • [   0% ] waiting    4m11.0s
+autocomplete              • [   0% ] waiting    6m41.0s
+get_by_id                 • [   0% ] waiting    09m11.0s
+get_categories            • [   0% ] waiting    11m41.0s
+
+running (00m50.0s), 10/51 VUs, 6 complete and 0 interrupted iterations
+full_text_search            [  33% ] 10/50 VUs  0m50.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m40.0s
+multi_field_search        • [   0% ] waiting    4m10.0s
+autocomplete              • [   0% ] waiting    6m40.0s
+get_by_id                 • [   0% ] waiting    09m10.0s
+get_categories            • [   0% ] waiting    11m40.0s
+
+running (00m51.0s), 10/51 VUs, 6 complete and 0 interrupted iterations
+full_text_search            [  34% ] 10/50 VUs  0m51.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m39.0s
+multi_field_search        • [   0% ] waiting    4m09.0s
+autocomplete              • [   0% ] waiting    6m39.0s
+get_by_id                 • [   0% ] waiting    09m09.0s
+get_categories            • [   0% ] waiting    11m39.0s
+
+running (00m52.0s), 10/51 VUs, 6 complete and 0 interrupted iterations
+full_text_search            [  35% ] 10/50 VUs  0m52.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m38.0s
+multi_field_search        • [   0% ] waiting    4m08.0s
+autocomplete              • [   0% ] waiting    6m38.0s
+get_by_id                 • [   0% ] waiting    09m08.0s
+get_categories            • [   0% ] waiting    11m38.0s
+
+running (00m53.0s), 10/51 VUs, 6 complete and 0 interrupted iterations
+full_text_search            [  35% ] 10/50 VUs  0m53.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m37.0s
+multi_field_search        • [   0% ] waiting    4m07.0s
+autocomplete              • [   0% ] waiting    6m37.0s
+get_by_id                 • [   0% ] waiting    09m07.0s
+get_categories            • [   0% ] waiting    11m37.0s
+
+running (00m54.0s), 10/51 VUs, 6 complete and 0 interrupted iterations
+full_text_search            [  36% ] 10/50 VUs  0m54.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m36.0s
+multi_field_search        • [   0% ] waiting    4m06.0s
+autocomplete              • [   0% ] waiting    6m36.0s
+get_by_id                 • [   0% ] waiting    09m06.0s
+get_categories            • [   0% ] waiting    11m36.0s
+
+running (00m55.0s), 10/51 VUs, 6 complete and 0 interrupted iterations
+full_text_search            [  37% ] 10/50 VUs  0m55.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m35.0s
+multi_field_search        • [   0% ] waiting    4m05.0s
+autocomplete              • [   0% ] waiting    6m35.0s
+get_by_id                 • [   0% ] waiting    09m05.0s
+get_categories            • [   0% ] waiting    11m35.0s
+
+running (00m56.0s), 10/51 VUs, 6 complete and 0 interrupted iterations
+full_text_search            [  37% ] 10/50 VUs  0m56.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m34.0s
+multi_field_search        • [   0% ] waiting    4m04.0s
+autocomplete              • [   0% ] waiting    6m34.0s
+get_by_id                 • [   0% ] waiting    09m04.0s
+get_categories            • [   0% ] waiting    11m34.0s
+
+running (00m57.0s), 10/51 VUs, 6 complete and 0 interrupted iterations
+full_text_search            [  38% ] 10/50 VUs  0m57.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m33.0s
+multi_field_search        • [   0% ] waiting    4m03.0s
+autocomplete              • [   0% ] waiting    6m33.0s
+get_by_id                 • [   0% ] waiting    09m03.0s
+get_categories            • [   0% ] waiting    11m33.0s
+
+running (00m58.0s), 10/51 VUs, 6 complete and 0 interrupted iterations
+full_text_search            [  39% ] 10/50 VUs  0m58.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m32.0s
+multi_field_search        • [   0% ] waiting    4m02.0s
+autocomplete              • [   0% ] waiting    6m32.0s
+get_by_id                 • [   0% ] waiting    09m02.0s
+get_categories            • [   0% ] waiting    11m32.0s
+
+running (00m59.0s), 10/51 VUs, 6 complete and 0 interrupted iterations
+full_text_search            [  39% ] 10/50 VUs  0m59.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m31.0s
+multi_field_search        • [   0% ] waiting    4m01.0s
+autocomplete              • [   0% ] waiting    6m31.0s
+get_by_id                 • [   0% ] waiting    09m01.0s
+get_categories            • [   0% ] waiting    11m31.0s
+
+running (01m00.0s), 10/51 VUs, 6 complete and 0 interrupted iterations
+full_text_search            [  40% ] 10/50 VUs  1m00.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m30.0s
+multi_field_search        • [   0% ] waiting    4m00.0s
+autocomplete              • [   0% ] waiting    6m30.0s
+get_by_id                 • [   0% ] waiting    09m00.0s
+get_categories            • [   0% ] waiting    11m30.0s
+time="2026-03-12T13:19:15Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=ceramic%20mug&size=20&page=0\": request timeout"
+
+running (01m01.0s), 10/51 VUs, 7 complete and 0 interrupted iterations
+full_text_search            [  41% ] 10/50 VUs  1m01.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m29.0s
+multi_field_search        • [   0% ] waiting    3m59.0s
+autocomplete              • [   0% ] waiting    6m29.0s
+get_by_id                 • [   0% ] waiting    08m59.0s
+get_categories            • [   0% ] waiting    11m29.0s
+
+running (01m02.0s), 10/51 VUs, 7 complete and 0 interrupted iterations
+full_text_search            [  41% ] 10/50 VUs  1m02.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m28.0s
+multi_field_search        • [   0% ] waiting    3m58.0s
+autocomplete              • [   0% ] waiting    6m28.0s
+get_by_id                 • [   0% ] waiting    08m58.0s
+get_categories            • [   0% ] waiting    11m28.0s
+
+running (01m03.0s), 10/51 VUs, 7 complete and 0 interrupted iterations
+full_text_search            [  42% ] 10/50 VUs  1m03.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m27.0s
+multi_field_search        • [   0% ] waiting    3m57.0s
+autocomplete              • [   0% ] waiting    6m27.0s
+get_by_id                 • [   0% ] waiting    08m57.0s
+get_categories            • [   0% ] waiting    11m27.0s
+
+running (01m04.0s), 10/51 VUs, 7 complete and 0 interrupted iterations
+full_text_search            [  43% ] 10/50 VUs  1m04.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m26.0s
+multi_field_search        • [   0% ] waiting    3m56.0s
+autocomplete              • [   0% ] waiting    6m26.0s
+get_by_id                 • [   0% ] waiting    08m56.0s
+get_categories            • [   0% ] waiting    11m26.0s
+
+running (01m05.0s), 10/51 VUs, 7 complete and 0 interrupted iterations
+full_text_search            [  43% ] 10/50 VUs  1m05.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m25.0s
+multi_field_search        • [   0% ] waiting    3m55.0s
+autocomplete              • [   0% ] waiting    6m25.0s
+get_by_id                 • [   0% ] waiting    08m55.0s
+get_categories            • [   0% ] waiting    11m25.0s
+
+running (01m06.0s), 10/51 VUs, 7 complete and 0 interrupted iterations
+full_text_search            [  44% ] 10/50 VUs  1m06.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m24.0s
+multi_field_search        • [   0% ] waiting    3m54.0s
+autocomplete              • [   0% ] waiting    6m24.0s
+get_by_id                 • [   0% ] waiting    08m54.0s
+get_categories            • [   0% ] waiting    11m24.0s
+
+running (01m07.0s), 10/51 VUs, 7 complete and 0 interrupted iterations
+full_text_search            [  45% ] 10/50 VUs  1m07.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m23.0s
+multi_field_search        • [   0% ] waiting    3m53.0s
+autocomplete              • [   0% ] waiting    6m23.0s
+get_by_id                 • [   0% ] waiting    08m53.0s
+get_categories            • [   0% ] waiting    11m23.0s
+
+running (01m08.0s), 10/51 VUs, 7 complete and 0 interrupted iterations
+full_text_search            [  45% ] 10/50 VUs  1m08.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m22.0s
+multi_field_search        • [   0% ] waiting    3m52.0s
+autocomplete              • [   0% ] waiting    6m22.0s
+get_by_id                 • [   0% ] waiting    08m52.0s
+get_categories            • [   0% ] waiting    11m22.0s
+
+running (01m09.0s), 10/51 VUs, 7 complete and 0 interrupted iterations
+full_text_search            [  46% ] 10/50 VUs  1m09.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m21.0s
+multi_field_search        • [   0% ] waiting    3m51.0s
+autocomplete              • [   0% ] waiting    6m21.0s
+get_by_id                 • [   0% ] waiting    08m51.0s
+get_categories            • [   0% ] waiting    11m21.0s
+
+running (01m10.0s), 10/51 VUs, 7 complete and 0 interrupted iterations
+full_text_search            [  47% ] 10/50 VUs  1m10.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m20.0s
+multi_field_search        • [   0% ] waiting    3m50.0s
+autocomplete              • [   0% ] waiting    6m20.0s
+get_by_id                 • [   0% ] waiting    08m50.0s
+get_categories            • [   0% ] waiting    11m20.0s
+
+running (01m11.0s), 10/51 VUs, 7 complete and 0 interrupted iterations
+full_text_search            [  47% ] 10/50 VUs  1m11.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m19.0s
+multi_field_search        • [   0% ] waiting    3m49.0s
+autocomplete              • [   0% ] waiting    6m19.0s
+get_by_id                 • [   0% ] waiting    08m49.0s
+get_categories            • [   0% ] waiting    11m19.0s
+
+running (01m12.0s), 10/51 VUs, 7 complete and 0 interrupted iterations
+full_text_search            [  48% ] 10/50 VUs  1m12.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m18.0s
+multi_field_search        • [   0% ] waiting    3m48.0s
+autocomplete              • [   0% ] waiting    6m18.0s
+get_by_id                 • [   0% ] waiting    08m48.0s
+get_categories            • [   0% ] waiting    11m18.0s
+
+running (01m13.0s), 10/51 VUs, 7 complete and 0 interrupted iterations
+full_text_search            [  49% ] 10/50 VUs  1m13.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m17.0s
+multi_field_search        • [   0% ] waiting    3m47.0s
+autocomplete              • [   0% ] waiting    6m17.0s
+get_by_id                 • [   0% ] waiting    08m47.0s
+get_categories            • [   0% ] waiting    11m17.0s
+
+running (01m14.0s), 10/51 VUs, 7 complete and 0 interrupted iterations
+full_text_search            [  49% ] 10/50 VUs  1m14.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m16.0s
+multi_field_search        • [   0% ] waiting    3m46.0s
+autocomplete              • [   0% ] waiting    6m16.0s
+get_by_id                 • [   0% ] waiting    08m46.0s
+get_categories            • [   0% ] waiting    11m16.0s
+
+running (01m15.0s), 10/51 VUs, 7 complete and 0 interrupted iterations
+full_text_search            [  50% ] 10/50 VUs  1m15.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m15.0s
+multi_field_search        • [   0% ] waiting    3m45.0s
+autocomplete              • [   0% ] waiting    6m15.0s
+get_by_id                 • [   0% ] waiting    08m45.0s
+get_categories            • [   0% ] waiting    11m15.0s
+
+running (01m16.0s), 11/51 VUs, 7 complete and 0 interrupted iterations
+full_text_search            [  51% ] 11/50 VUs  1m16.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m14.0s
+multi_field_search        • [   0% ] waiting    3m44.0s
+autocomplete              • [   0% ] waiting    6m14.0s
+get_by_id                 • [   0% ] waiting    08m44.0s
+get_categories            • [   0% ] waiting    11m14.0s
+
+running (01m17.0s), 12/51 VUs, 7 complete and 0 interrupted iterations
+full_text_search            [  51% ] 12/50 VUs  1m17.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m13.0s
+multi_field_search        • [   0% ] waiting    3m43.0s
+autocomplete              • [   0% ] waiting    6m13.0s
+get_by_id                 • [   0% ] waiting    08m43.0s
+get_categories            • [   0% ] waiting    11m13.0s
+
+running (01m18.0s), 13/51 VUs, 7 complete and 0 interrupted iterations
+full_text_search            [  52% ] 13/50 VUs  1m18.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m12.0s
+multi_field_search        • [   0% ] waiting    3m42.0s
+autocomplete              • [   0% ] waiting    6m12.0s
+get_by_id                 • [   0% ] waiting    08m42.0s
+get_categories            • [   0% ] waiting    11m12.0s
+time="2026-03-12T13:19:34Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=cotton%20shirt&size=20&page=0\": request timeout"
+
+running (01m19.0s), 15/51 VUs, 7 complete and 0 interrupted iterations
+full_text_search            [  53% ] 15/50 VUs  1m19.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m11.0s
+multi_field_search        • [   0% ] waiting    3m41.0s
+autocomplete              • [   0% ] waiting    6m11.0s
+get_by_id                 • [   0% ] waiting    08m41.0s
+get_categories            • [   0% ] waiting    11m11.0s
+
+running (01m20.0s), 16/51 VUs, 8 complete and 0 interrupted iterations
+full_text_search            [  53% ] 16/50 VUs  1m20.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m10.0s
+multi_field_search        • [   0% ] waiting    3m40.0s
+autocomplete              • [   0% ] waiting    6m10.0s
+get_by_id                 • [   0% ] waiting    08m40.0s
+get_categories            • [   0% ] waiting    11m10.0s
+
+running (01m21.0s), 17/51 VUs, 8 complete and 0 interrupted iterations
+full_text_search            [  54% ] 17/50 VUs  1m21.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m09.0s
+multi_field_search        • [   0% ] waiting    3m39.0s
+autocomplete              • [   0% ] waiting    6m09.0s
+get_by_id                 • [   0% ] waiting    08m39.0s
+get_categories            • [   0% ] waiting    11m09.0s
+time="2026-03-12T13:19:37Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=glass%20vase&size=20&page=2\": request timeout"
+time="2026-03-12T13:19:37Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=leather%20wallet&size=20&page=2\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (01m22.0s), 19/51 VUs, 8 complete and 0 interrupted iterations
+full_text_search            [  55% ] 19/50 VUs  1m22.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m08.0s
+multi_field_search        • [   0% ] waiting    3m38.0s
+autocomplete              • [   0% ] waiting    6m08.0s
+get_by_id                 • [   0% ] waiting    08m38.0s
+get_categories            • [   0% ] waiting    11m08.0s
+time="2026-03-12T13:19:37Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=canvas%20bag&size=20&page=3\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (01m23.0s), 20/51 VUs, 10 complete and 0 interrupted iterations
+full_text_search            [  55% ] 20/50 VUs  1m23.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m07.0s
+multi_field_search        • [   0% ] waiting    3m37.0s
+autocomplete              • [   0% ] waiting    6m07.0s
+get_by_id                 • [   0% ] waiting    08m37.0s
+get_categories            • [   0% ] waiting    11m07.0s
+
+running (01m24.0s), 21/51 VUs, 11 complete and 0 interrupted iterations
+full_text_search            [  56% ] 21/50 VUs  1m24.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m06.0s
+multi_field_search        • [   0% ] waiting    3m36.0s
+autocomplete              • [   0% ] waiting    6m06.0s
+get_by_id                 • [   0% ] waiting    08m36.0s
+get_categories            • [   0% ] waiting    11m06.0s
+
+running (01m25.0s), 23/51 VUs, 11 complete and 0 interrupted iterations
+full_text_search            [  57% ] 23/50 VUs  1m25.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m05.0s
+multi_field_search        • [   0% ] waiting    3m35.0s
+autocomplete              • [   0% ] waiting    6m05.0s
+get_by_id                 • [   0% ] waiting    08m35.0s
+get_categories            • [   0% ] waiting    11m05.0s
+time="2026-03-12T13:19:40Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=silk%20scarf&size=20&page=1\": request timeout"
+
+running (01m26.0s), 24/51 VUs, 12 complete and 0 interrupted iterations
+full_text_search            [  57% ] 24/50 VUs  1m26.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m04.0s
+multi_field_search        • [   0% ] waiting    3m34.0s
+autocomplete              • [   0% ] waiting    6m04.0s
+get_by_id                 • [   0% ] waiting    08m34.0s
+get_categories            • [   0% ] waiting    11m04.0s
+
+running (01m27.0s), 25/51 VUs, 12 complete and 0 interrupted iterations
+full_text_search            [  58% ] 25/50 VUs  1m27.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m03.0s
+multi_field_search        • [   0% ] waiting    3m33.0s
+autocomplete              • [   0% ] waiting    6m03.0s
+get_by_id                 • [   0% ] waiting    08m33.0s
+get_categories            • [   0% ] waiting    11m03.0s
+time="2026-03-12T13:19:43Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=ceramic%20mug&size=20&page=2\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (01m28.0s), 27/51 VUs, 12 complete and 0 interrupted iterations
+full_text_search            [  59% ] 27/50 VUs  1m28.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m02.0s
+multi_field_search        • [   0% ] waiting    3m32.0s
+autocomplete              • [   0% ] waiting    6m02.0s
+get_by_id                 • [   0% ] waiting    08m32.0s
+get_categories            • [   0% ] waiting    11m02.0s
+time="2026-03-12T13:19:43Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=bronze%20ring&size=20&page=2\": dial tcp 172.20.150.69:80: connect: connection refused"
+time="2026-03-12T13:19:43Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=cotton%20shirt&size=20&page=1\": request timeout"
+time="2026-03-12T13:19:43Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=crystal%20earrings&size=20&page=2\": dial tcp 172.20.150.69:80: connect: connection refused"
+time="2026-03-12T13:19:44Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=suede%20boots&size=20&page=1\": dial tcp 172.20.150.69:80: connect: connection refused"
+time="2026-03-12T13:19:44Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=wool%20blanket&size=20&page=4\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (01m29.0s), 28/51 VUs, 15 complete and 0 interrupted iterations
+full_text_search            [  59% ] 28/50 VUs  1m29.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m01.0s
+multi_field_search        • [   0% ] waiting    3m31.0s
+autocomplete              • [   0% ] waiting    6m01.0s
+get_by_id                 • [   0% ] waiting    08m31.0s
+get_categories            • [   0% ] waiting    11m01.0s
+time="2026-03-12T13:19:44Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=denim%20jacket&size=20&page=3\": dial tcp 172.20.150.69:80: connect: connection refused"
+time="2026-03-12T13:19:44Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=copper%20lamp&size=20&page=0\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (01m30.0s), 29/51 VUs, 20 complete and 0 interrupted iterations
+full_text_search            [  60% ] 29/50 VUs  1m30.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    1m00.0s
+multi_field_search        • [   0% ] waiting    3m30.0s
+autocomplete              • [   0% ] waiting    6m00.0s
+get_by_id                 • [   0% ] waiting    08m30.0s
+get_categories            • [   0% ] waiting    11m00.0s
+
+running (01m31.0s), 31/51 VUs, 20 complete and 0 interrupted iterations
+full_text_search            [  61% ] 31/50 VUs  1m31.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m59.0s
+multi_field_search        • [   0% ] waiting    3m29.0s
+autocomplete              • [   0% ] waiting    5m59.0s
+get_by_id                 • [   0% ] waiting    08m29.0s
+get_categories            • [   0% ] waiting    10m59.0s
+time="2026-03-12T13:19:46Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=bamboo%20bottle&size=20&page=3\": dial tcp 172.20.150.69:80: connect: connection refused"
+time="2026-03-12T13:19:47Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=marble%20table&size=20&page=4\": request timeout"
+
+running (01m32.0s), 32/51 VUs, 20 complete and 0 interrupted iterations
+full_text_search            [  61% ] 32/50 VUs  1m32.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m58.0s
+multi_field_search        • [   0% ] waiting    3m28.0s
+autocomplete              • [   0% ] waiting    5m58.0s
+get_by_id                 • [   0% ] waiting    08m28.0s
+get_categories            • [   0% ] waiting    10m58.0s
+time="2026-03-12T13:19:47Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=denim%20jacket&size=20&page=0\": dial tcp 172.20.150.69:80: connect: connection refused"
+time="2026-03-12T13:19:47Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=leather%20wallet&size=20&page=3\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (01m33.0s), 33/51 VUs, 24 complete and 0 interrupted iterations
+full_text_search            [  62% ] 33/50 VUs  1m33.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m57.0s
+multi_field_search        • [   0% ] waiting    3m27.0s
+autocomplete              • [   0% ] waiting    5m57.0s
+get_by_id                 • [   0% ] waiting    08m27.0s
+get_categories            • [   0% ] waiting    10m57.0s
+time="2026-03-12T13:19:49Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=suede%20boots&size=20&page=2\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (01m34.0s), 35/51 VUs, 24 complete and 0 interrupted iterations
+full_text_search            [  63% ] 35/50 VUs  1m34.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m56.0s
+multi_field_search        • [   0% ] waiting    3m26.0s
+autocomplete              • [   0% ] waiting    5m56.0s
+get_by_id                 • [   0% ] waiting    08m26.0s
+get_categories            • [   0% ] waiting    10m56.0s
+time="2026-03-12T13:19:49Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=bamboo%20bottle&size=20&page=0\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (01m35.0s), 36/51 VUs, 26 complete and 0 interrupted iterations
+full_text_search            [  63% ] 36/50 VUs  1m35.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m55.0s
+multi_field_search        • [   0% ] waiting    3m25.0s
+autocomplete              • [   0% ] waiting    5m55.0s
+get_by_id                 • [   0% ] waiting    08m25.0s
+get_categories            • [   0% ] waiting    10m55.0s
+
+running (01m36.0s), 37/51 VUs, 26 complete and 0 interrupted iterations
+full_text_search            [  64% ] 37/50 VUs  1m36.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m54.0s
+multi_field_search        • [   0% ] waiting    3m24.0s
+autocomplete              • [   0% ] waiting    5m54.0s
+get_by_id                 • [   0% ] waiting    08m24.0s
+get_categories            • [   0% ] waiting    10m54.0s
+time="2026-03-12T13:19:51Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=canvas%20bag&size=20&page=4\": request timeout"
+
+running (01m37.0s), 39/51 VUs, 27 complete and 0 interrupted iterations
+full_text_search            [  65% ] 39/50 VUs  1m37.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m53.0s
+multi_field_search        • [   0% ] waiting    3m23.0s
+autocomplete              • [   0% ] waiting    5m53.0s
+get_by_id                 • [   0% ] waiting    08m23.0s
+get_categories            • [   0% ] waiting    10m53.0s
+
+running (01m38.0s), 40/51 VUs, 27 complete and 0 interrupted iterations
+full_text_search            [  65% ] 40/50 VUs  1m38.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m52.0s
+multi_field_search        • [   0% ] waiting    3m22.0s
+autocomplete              • [   0% ] waiting    5m52.0s
+get_by_id                 • [   0% ] waiting    08m22.0s
+get_categories            • [   0% ] waiting    10m52.0s
+time="2026-03-12T13:19:53Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=silk%20scarf&size=20&page=0\": dial tcp 172.20.150.69:80: connect: connection refused"
+time="2026-03-12T13:19:53Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=steel%20belt&size=20&page=1\": request timeout"
+time="2026-03-12T13:19:54Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=carbon%20cable&size=20&page=4\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (01m39.0s), 41/51 VUs, 29 complete and 0 interrupted iterations
+full_text_search            [  66% ] 41/50 VUs  1m39.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m51.0s
+multi_field_search        • [   0% ] waiting    3m21.0s
+autocomplete              • [   0% ] waiting    5m51.0s
+get_by_id                 • [   0% ] waiting    08m21.0s
+get_categories            • [   0% ] waiting    10m51.0s
+time="2026-03-12T13:19:55Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=bamboo%20bottle&size=20&page=0\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (01m40.0s), 43/51 VUs, 30 complete and 0 interrupted iterations
+full_text_search            [  67% ] 43/50 VUs  1m40.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m50.0s
+multi_field_search        • [   0% ] waiting    3m20.0s
+autocomplete              • [   0% ] waiting    5m50.0s
+get_by_id                 • [   0% ] waiting    08m20.0s
+get_categories            • [   0% ] waiting    10m50.0s
+time="2026-03-12T13:19:55Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=denim%20jacket&size=20&page=0\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (01m41.0s), 44/51 VUs, 31 complete and 0 interrupted iterations
+full_text_search            [  67% ] 44/50 VUs  1m41.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m49.0s
+multi_field_search        • [   0% ] waiting    3m19.0s
+autocomplete              • [   0% ] waiting    5m49.0s
+get_by_id                 • [   0% ] waiting    08m19.0s
+get_categories            • [   0% ] waiting    10m49.0s
+time="2026-03-12T13:19:56Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=wool%20blanket&size=20&page=2\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (01m42.0s), 45/51 VUs, 33 complete and 0 interrupted iterations
+full_text_search            [  68% ] 45/50 VUs  1m42.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m48.0s
+multi_field_search        • [   0% ] waiting    3m18.0s
+autocomplete              • [   0% ] waiting    5m48.0s
+get_by_id                 • [   0% ] waiting    08m18.0s
+get_categories            • [   0% ] waiting    10m48.0s
+time="2026-03-12T13:19:58Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=suede%20boots&size=20&page=4\": request timeout"
+time="2026-03-12T13:19:58Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=ceramic%20mug&size=20&page=1\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (01m43.0s), 47/51 VUs, 33 complete and 0 interrupted iterations
+full_text_search            [  69% ] 47/50 VUs  1m43.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m47.0s
+multi_field_search        • [   0% ] waiting    3m17.0s
+autocomplete              • [   0% ] waiting    5m47.0s
+get_by_id                 • [   0% ] waiting    08m17.0s
+get_categories            • [   0% ] waiting    10m47.0s
+time="2026-03-12T13:19:58Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=wooden%20chair&size=20&page=1\": dial tcp 172.20.150.69:80: connect: connection refused"
+time="2026-03-12T13:19:58Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=silk%20scarf&size=20&page=3\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (01m44.0s), 48/51 VUs, 36 complete and 0 interrupted iterations
+full_text_search            [  69% ] 48/50 VUs  1m44.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m46.0s
+multi_field_search        • [   0% ] waiting    3m16.0s
+autocomplete              • [   0% ] waiting    5m46.0s
+get_by_id                 • [   0% ] waiting    08m16.0s
+get_categories            • [   0% ] waiting    10m46.0s
+
+running (01m45.0s), 49/51 VUs, 37 complete and 0 interrupted iterations
+full_text_search            [  70% ] 49/50 VUs  1m45.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m45.0s
+multi_field_search        • [   0% ] waiting    3m15.0s
+autocomplete              • [   0% ] waiting    5m45.0s
+get_by_id                 • [   0% ] waiting    08m15.0s
+get_categories            • [   0% ] waiting    10m45.0s
+time="2026-03-12T13:20:00Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=ceramic%20mug&size=20&page=3\": request timeout"
+
+running (01m46.0s), 50/51 VUs, 37 complete and 0 interrupted iterations
+full_text_search            [  71% ] 50/50 VUs  1m46.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m44.0s
+multi_field_search        • [   0% ] waiting    3m14.0s
+autocomplete              • [   0% ] waiting    5m44.0s
+get_by_id                 • [   0% ] waiting    08m14.0s
+get_categories            • [   0% ] waiting    10m44.0s
+
+running (01m47.0s), 50/51 VUs, 38 complete and 0 interrupted iterations
+full_text_search            [  71% ] 50/50 VUs  1m47.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m43.0s
+multi_field_search        • [   0% ] waiting    3m13.0s
+autocomplete              • [   0% ] waiting    5m43.0s
+get_by_id                 • [   0% ] waiting    08m13.0s
+get_categories            • [   0% ] waiting    10m43.0s
+
+running (01m48.0s), 50/51 VUs, 38 complete and 0 interrupted iterations
+full_text_search            [  72% ] 50/50 VUs  1m48.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m42.0s
+multi_field_search        • [   0% ] waiting    3m12.0s
+autocomplete              • [   0% ] waiting    5m42.0s
+get_by_id                 • [   0% ] waiting    08m12.0s
+get_categories            • [   0% ] waiting    10m42.0s
+
+running (01m49.0s), 50/51 VUs, 38 complete and 0 interrupted iterations
+full_text_search            [  73% ] 50/50 VUs  1m49.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m41.0s
+multi_field_search        • [   0% ] waiting    3m11.0s
+autocomplete              • [   0% ] waiting    5m41.0s
+get_by_id                 • [   0% ] waiting    08m11.0s
+get_categories            • [   0% ] waiting    10m41.0s
+
+running (01m50.0s), 50/51 VUs, 38 complete and 0 interrupted iterations
+full_text_search            [  73% ] 50/50 VUs  1m50.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m40.0s
+multi_field_search        • [   0% ] waiting    3m10.0s
+autocomplete              • [   0% ] waiting    5m40.0s
+get_by_id                 • [   0% ] waiting    08m10.0s
+get_categories            • [   0% ] waiting    10m40.0s
+
+running (01m51.0s), 50/51 VUs, 40 complete and 0 interrupted iterations
+full_text_search            [  74% ] 50/50 VUs  1m51.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m39.0s
+multi_field_search        • [   0% ] waiting    3m09.0s
+autocomplete              • [   0% ] waiting    5m39.0s
+get_by_id                 • [   0% ] waiting    08m09.0s
+get_categories            • [   0% ] waiting    10m39.0s
+
+running (01m52.0s), 50/51 VUs, 40 complete and 0 interrupted iterations
+full_text_search            [  75% ] 50/50 VUs  1m52.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m38.0s
+multi_field_search        • [   0% ] waiting    3m08.0s
+autocomplete              • [   0% ] waiting    5m38.0s
+get_by_id                 • [   0% ] waiting    08m08.0s
+get_categories            • [   0% ] waiting    10m38.0s
+
+running (01m53.0s), 50/51 VUs, 40 complete and 0 interrupted iterations
+full_text_search            [  75% ] 50/50 VUs  1m53.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m37.0s
+multi_field_search        • [   0% ] waiting    3m07.0s
+autocomplete              • [   0% ] waiting    5m37.0s
+get_by_id                 • [   0% ] waiting    08m07.0s
+get_categories            • [   0% ] waiting    10m37.0s
+
+running (01m54.0s), 50/51 VUs, 42 complete and 0 interrupted iterations
+full_text_search            [  76% ] 50/50 VUs  1m54.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m36.0s
+multi_field_search        • [   0% ] waiting    3m06.0s
+autocomplete              • [   0% ] waiting    5m36.0s
+get_by_id                 • [   0% ] waiting    08m06.0s
+get_categories            • [   0% ] waiting    10m36.0s
+
+running (01m55.0s), 50/51 VUs, 43 complete and 0 interrupted iterations
+full_text_search            [  77% ] 50/50 VUs  1m55.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m35.0s
+multi_field_search        • [   0% ] waiting    3m05.0s
+autocomplete              • [   0% ] waiting    5m35.0s
+get_by_id                 • [   0% ] waiting    08m05.0s
+get_categories            • [   0% ] waiting    10m35.0s
+
+running (01m56.0s), 50/51 VUs, 44 complete and 0 interrupted iterations
+full_text_search            [  77% ] 50/50 VUs  1m56.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m34.0s
+multi_field_search        • [   0% ] waiting    3m04.0s
+autocomplete              • [   0% ] waiting    5m34.0s
+get_by_id                 • [   0% ] waiting    08m04.0s
+get_categories            • [   0% ] waiting    10m34.0s
+
+running (01m57.0s), 50/51 VUs, 47 complete and 0 interrupted iterations
+full_text_search            [  78% ] 50/50 VUs  1m57.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m33.0s
+multi_field_search        • [   0% ] waiting    3m03.0s
+autocomplete              • [   0% ] waiting    5m33.0s
+get_by_id                 • [   0% ] waiting    08m03.0s
+get_categories            • [   0% ] waiting    10m33.0s
+
+running (01m58.0s), 50/51 VUs, 48 complete and 0 interrupted iterations
+full_text_search            [  79% ] 50/50 VUs  1m58.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m32.0s
+multi_field_search        • [   0% ] waiting    3m02.0s
+autocomplete              • [   0% ] waiting    5m32.0s
+get_by_id                 • [   0% ] waiting    08m02.0s
+get_categories            • [   0% ] waiting    10m32.0s
+
+running (01m59.0s), 50/51 VUs, 48 complete and 0 interrupted iterations
+full_text_search            [  79% ] 50/50 VUs  1m59.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m31.0s
+multi_field_search        • [   0% ] waiting    3m01.0s
+autocomplete              • [   0% ] waiting    5m31.0s
+get_by_id                 • [   0% ] waiting    08m01.0s
+get_categories            • [   0% ] waiting    10m31.0s
+
+running (02m00.0s), 50/51 VUs, 50 complete and 0 interrupted iterations
+full_text_search            [  80% ] 50/50 VUs  2m00.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m30.0s
+multi_field_search        • [   0% ] waiting    3m00.0s
+autocomplete              • [   0% ] waiting    5m30.0s
+get_by_id                 • [   0% ] waiting    08m00.0s
+get_categories            • [   0% ] waiting    10m30.0s
+time="2026-03-12T13:20:15Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=crystal%20earrings&size=20&page=1\": request timeout"
+
+running (02m01.0s), 50/51 VUs, 53 complete and 0 interrupted iterations
+full_text_search            [  81% ] 50/50 VUs  2m01.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m29.0s
+multi_field_search        • [   0% ] waiting    2m59.0s
+autocomplete              • [   0% ] waiting    5m29.0s
+get_by_id                 • [   0% ] waiting    07m59.0s
+get_categories            • [   0% ] waiting    10m29.0s
+
+running (02m02.0s), 50/51 VUs, 55 complete and 0 interrupted iterations
+full_text_search            [  81% ] 50/50 VUs  2m02.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m28.0s
+multi_field_search        • [   0% ] waiting    2m58.0s
+autocomplete              • [   0% ] waiting    5m28.0s
+get_by_id                 • [   0% ] waiting    07m58.0s
+get_categories            • [   0% ] waiting    10m28.0s
+
+running (02m03.0s), 50/51 VUs, 56 complete and 0 interrupted iterations
+full_text_search            [  82% ] 50/50 VUs  2m03.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m27.0s
+multi_field_search        • [   0% ] waiting    2m57.0s
+autocomplete              • [   0% ] waiting    5m27.0s
+get_by_id                 • [   0% ] waiting    07m57.0s
+get_categories            • [   0% ] waiting    10m27.0s
+
+running (02m04.0s), 50/51 VUs, 59 complete and 0 interrupted iterations
+full_text_search            [  83% ] 50/50 VUs  2m04.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m26.0s
+multi_field_search        • [   0% ] waiting    2m56.0s
+autocomplete              • [   0% ] waiting    5m26.0s
+get_by_id                 • [   0% ] waiting    07m56.0s
+get_categories            • [   0% ] waiting    10m26.0s
+
+running (02m05.0s), 50/51 VUs, 59 complete and 0 interrupted iterations
+full_text_search            [  83% ] 50/50 VUs  2m05.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m25.0s
+multi_field_search        • [   0% ] waiting    2m55.0s
+autocomplete              • [   0% ] waiting    5m25.0s
+get_by_id                 • [   0% ] waiting    07m55.0s
+get_categories            • [   0% ] waiting    10m25.0s
+
+running (02m06.0s), 50/51 VUs, 62 complete and 0 interrupted iterations
+full_text_search            [  84% ] 50/50 VUs  2m06.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m24.0s
+multi_field_search        • [   0% ] waiting    2m54.0s
+autocomplete              • [   0% ] waiting    5m24.0s
+get_by_id                 • [   0% ] waiting    07m54.0s
+get_categories            • [   0% ] waiting    10m24.0s
+
+running (02m07.0s), 50/51 VUs, 63 complete and 0 interrupted iterations
+full_text_search            [  85% ] 50/50 VUs  2m07.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m23.0s
+multi_field_search        • [   0% ] waiting    2m53.0s
+autocomplete              • [   0% ] waiting    5m23.0s
+get_by_id                 • [   0% ] waiting    07m53.0s
+get_categories            • [   0% ] waiting    10m23.0s
+
+running (02m08.0s), 50/51 VUs, 65 complete and 0 interrupted iterations
+full_text_search            [  85% ] 50/50 VUs  2m08.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m22.0s
+multi_field_search        • [   0% ] waiting    2m52.0s
+autocomplete              • [   0% ] waiting    5m22.0s
+get_by_id                 • [   0% ] waiting    07m52.0s
+get_categories            • [   0% ] waiting    10m22.0s
+
+running (02m09.0s), 50/51 VUs, 66 complete and 0 interrupted iterations
+full_text_search            [  86% ] 50/50 VUs  2m09.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m21.0s
+multi_field_search        • [   0% ] waiting    2m51.0s
+autocomplete              • [   0% ] waiting    5m21.0s
+get_by_id                 • [   0% ] waiting    07m51.0s
+get_categories            • [   0% ] waiting    10m21.0s
+
+running (02m10.0s), 50/51 VUs, 69 complete and 0 interrupted iterations
+full_text_search            [  87% ] 50/50 VUs  2m10.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m20.0s
+multi_field_search        • [   0% ] waiting    2m50.0s
+autocomplete              • [   0% ] waiting    5m20.0s
+get_by_id                 • [   0% ] waiting    07m50.0s
+get_categories            • [   0% ] waiting    10m20.0s
+
+running (02m11.0s), 50/51 VUs, 70 complete and 0 interrupted iterations
+full_text_search            [  87% ] 50/50 VUs  2m11.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m19.0s
+multi_field_search        • [   0% ] waiting    2m49.0s
+autocomplete              • [   0% ] waiting    5m19.0s
+get_by_id                 • [   0% ] waiting    07m49.0s
+get_categories            • [   0% ] waiting    10m19.0s
+
+running (02m12.0s), 50/51 VUs, 71 complete and 0 interrupted iterations
+full_text_search            [  88% ] 50/50 VUs  2m12.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m18.0s
+multi_field_search        • [   0% ] waiting    2m48.0s
+autocomplete              • [   0% ] waiting    5m18.0s
+get_by_id                 • [   0% ] waiting    07m48.0s
+get_categories            • [   0% ] waiting    10m18.0s
+
+running (02m13.0s), 50/51 VUs, 73 complete and 0 interrupted iterations
+full_text_search            [  89% ] 50/50 VUs  2m13.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m17.0s
+multi_field_search        • [   0% ] waiting    2m47.0s
+autocomplete              • [   0% ] waiting    5m17.0s
+get_by_id                 • [   0% ] waiting    07m47.0s
+get_categories            • [   0% ] waiting    10m17.0s
+
+running (02m14.0s), 50/51 VUs, 74 complete and 0 interrupted iterations
+full_text_search            [  89% ] 50/50 VUs  2m14.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m16.0s
+multi_field_search        • [   0% ] waiting    2m46.0s
+autocomplete              • [   0% ] waiting    5m16.0s
+get_by_id                 • [   0% ] waiting    07m46.0s
+get_categories            • [   0% ] waiting    10m16.0s
+
+running (02m15.0s), 50/51 VUs, 77 complete and 0 interrupted iterations
+full_text_search            [  90% ] 50/50 VUs  2m15.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m15.0s
+multi_field_search        • [   0% ] waiting    2m45.0s
+autocomplete              • [   0% ] waiting    5m15.0s
+get_by_id                 • [   0% ] waiting    07m45.0s
+get_categories            • [   0% ] waiting    10m15.0s
+time="2026-03-12T13:20:31Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=cotton%20shirt&size=20&page=2\": request timeout"
+
+running (02m16.0s), 49/51 VUs, 78 complete and 0 interrupted iterations
+full_text_search            [  91% ] 49/50 VUs  2m16.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m14.0s
+multi_field_search        • [   0% ] waiting    2m44.0s
+autocomplete              • [   0% ] waiting    5m14.0s
+get_by_id                 • [   0% ] waiting    07m44.0s
+get_categories            • [   0% ] waiting    10m14.0s
+time="2026-03-12T13:20:31Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=crystal%20earrings&size=20&page=1\": request timeout"
+
+running (02m17.0s), 49/51 VUs, 80 complete and 0 interrupted iterations
+full_text_search            [  91% ] 49/50 VUs  2m17.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m13.0s
+multi_field_search        • [   0% ] waiting    2m43.0s
+autocomplete              • [   0% ] waiting    5m13.0s
+get_by_id                 • [   0% ] waiting    07m43.0s
+get_categories            • [   0% ] waiting    10m13.0s
+time="2026-03-12T13:20:32Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=ceramic%20mug&size=20&page=2\": dial tcp 172.20.150.69:80: connect: connection refused"
+time="2026-03-12T13:20:32Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=wooden%20chair&size=20&page=2\": request timeout"
+
+running (02m18.0s), 49/51 VUs, 83 complete and 0 interrupted iterations
+full_text_search            [  92% ] 49/50 VUs  2m18.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m12.0s
+multi_field_search        • [   0% ] waiting    2m42.0s
+autocomplete              • [   0% ] waiting    5m12.0s
+get_by_id                 • [   0% ] waiting    07m42.0s
+get_categories            • [   0% ] waiting    10m12.0s
+time="2026-03-12T13:20:33Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=steel%20belt&size=20&page=2\": request timeout"
+time="2026-03-12T13:20:33Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=wool%20blanket&size=20&page=1\": dial tcp 172.20.150.69:80: connect: connection refused"
+time="2026-03-12T13:20:34Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=wool%20blanket&size=20&page=3\": request timeout"
+
+running (02m19.0s), 49/51 VUs, 84 complete and 0 interrupted iterations
+full_text_search            [  93% ] 49/50 VUs  2m19.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m11.0s
+multi_field_search        • [   0% ] waiting    2m41.0s
+autocomplete              • [   0% ] waiting    5m11.0s
+get_by_id                 • [   0% ] waiting    07m41.0s
+get_categories            • [   0% ] waiting    10m11.0s
+time="2026-03-12T13:20:34Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=bamboo%20bottle&size=20&page=4\": dial tcp 172.20.150.69:80: connect: connection refused"
+time="2026-03-12T13:20:34Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=leather%20wallet&size=20&page=0\": dial tcp 172.20.150.69:80: connect: connection refused"
+time="2026-03-12T13:20:34Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=glass%20vase&size=20&page=1\": request timeout"
+
+running (02m20.0s), 49/51 VUs, 89 complete and 0 interrupted iterations
+full_text_search            [  93% ] 49/50 VUs  2m20.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m10.0s
+multi_field_search        • [   0% ] waiting    2m40.0s
+autocomplete              • [   0% ] waiting    5m10.0s
+get_by_id                 • [   0% ] waiting    07m40.0s
+get_categories            • [   0% ] waiting    10m10.0s
+
+running (02m21.0s), 49/51 VUs, 90 complete and 0 interrupted iterations
+full_text_search            [  94% ] 49/50 VUs  2m21.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m09.0s
+multi_field_search        • [   0% ] waiting    2m39.0s
+autocomplete              • [   0% ] waiting    5m09.0s
+get_by_id                 • [   0% ] waiting    07m39.0s
+get_categories            • [   0% ] waiting    10m09.0s
+time="2026-03-12T13:20:36Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=copper%20lamp&size=20&page=0\": request timeout"
+
+running (02m22.0s), 49/51 VUs, 92 complete and 0 interrupted iterations
+full_text_search            [  95% ] 49/50 VUs  2m22.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m08.0s
+multi_field_search        • [   0% ] waiting    2m38.0s
+autocomplete              • [   0% ] waiting    5m08.0s
+get_by_id                 • [   0% ] waiting    07m38.0s
+get_categories            • [   0% ] waiting    10m08.0s
+time="2026-03-12T13:20:37Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=linen%20towel&size=20&page=2\": request timeout"
+time="2026-03-12T13:20:37Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=steel%20belt&size=20&page=2\": request timeout"
+
+running (02m23.0s), 49/51 VUs, 94 complete and 0 interrupted iterations
+full_text_search            [  95% ] 49/50 VUs  2m23.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m07.0s
+multi_field_search        • [   0% ] waiting    2m37.0s
+autocomplete              • [   0% ] waiting    5m07.0s
+get_by_id                 • [   0% ] waiting    07m37.0s
+get_categories            • [   0% ] waiting    10m07.0s
+
+running (02m24.0s), 49/51 VUs, 94 complete and 0 interrupted iterations
+full_text_search            [  96% ] 49/50 VUs  2m24.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m06.0s
+multi_field_search        • [   0% ] waiting    2m36.0s
+autocomplete              • [   0% ] waiting    5m06.0s
+get_by_id                 • [   0% ] waiting    07m36.0s
+get_categories            • [   0% ] waiting    10m06.0s
+
+running (02m25.0s), 48/51 VUs, 96 complete and 0 interrupted iterations
+full_text_search            [  97% ] 48/50 VUs  2m25.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m05.0s
+multi_field_search        • [   0% ] waiting    2m35.0s
+autocomplete              • [   0% ] waiting    5m05.0s
+get_by_id                 • [   0% ] waiting    07m35.0s
+get_categories            • [   0% ] waiting    10m05.0s
+
+running (02m26.0s), 46/51 VUs, 98 complete and 0 interrupted iterations
+full_text_search            [  97% ] 46/50 VUs  2m26.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m04.0s
+multi_field_search        • [   0% ] waiting    2m34.0s
+autocomplete              • [   0% ] waiting    5m04.0s
+get_by_id                 • [   0% ] waiting    07m34.0s
+get_categories            • [   0% ] waiting    10m04.0s
+
+running (02m27.0s), 45/51 VUs, 100 complete and 0 interrupted iterations
+full_text_search            [  98% ] 45/50 VUs  2m27.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m03.0s
+multi_field_search        • [   0% ] waiting    2m33.0s
+autocomplete              • [   0% ] waiting    5m03.0s
+get_by_id                 • [   0% ] waiting    07m33.0s
+get_categories            • [   0% ] waiting    10m03.0s
+
+running (02m28.0s), 44/51 VUs, 101 complete and 0 interrupted iterations
+full_text_search            [  99% ] 44/50 VUs  2m28.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m02.0s
+multi_field_search        • [   0% ] waiting    2m32.0s
+autocomplete              • [   0% ] waiting    5m02.0s
+get_by_id                 • [   0% ] waiting    07m32.0s
+get_categories            • [   0% ] waiting    10m02.0s
+
+running (02m29.0s), 43/51 VUs, 102 complete and 0 interrupted iterations
+full_text_search            [  99% ] 43/50 VUs  2m29.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m01.0s
+multi_field_search        • [   0% ] waiting    2m31.0s
+autocomplete              • [   0% ] waiting    5m01.0s
+get_by_id                 • [   0% ] waiting    07m31.0s
+get_categories            • [   0% ] waiting    10m01.0s
+
+running (02m30.0s), 43/51 VUs, 102 complete and 0 interrupted iterations
+full_text_search            [ 100% ] 43/50 VUs  2m30.0s/2m30.0s
+filtered_sorted_paginated • [   0% ] waiting    0m00.0s
+multi_field_search        • [   0% ] waiting    2m30.0s
+autocomplete              • [   0% ] waiting    5m00.0s
+get_by_id                 • [   0% ] waiting    07m30.0s
+get_categories            • [   0% ] waiting    10m00.0s
+time="2026-03-12T13:20:45Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?categoryName=Footwear&minPrice=537&maxPrice=1779&sortBy=price&sortDir=desc&size=20&page=6\": dial tcp 172.20.150.69:80: connect: connection refused"
+time="2026-03-12T13:20:45Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?categoryName=Sports%20%26%20Outdoors&minPrice=328&maxPrice=3747&sortBy=price&sortDir=asc&size=20&page=6\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (02m31.0s), 40/51 VUs, 107 complete and 0 interrupted iterations
+full_text_search          ↓ [ 100% ] 43/50 VUs  2m30s
+filtered_sorted_paginated   [   1% ] 01/50 VUs  0m01.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    2m29.0s
+autocomplete              • [   0% ] waiting    4m59.0s
+get_by_id                 • [   0% ] waiting    07m29.0s
+get_categories            • [   0% ] waiting    09m59.0s
+
+running (02m32.0s), 37/51 VUs, 111 complete and 0 interrupted iterations
+full_text_search          ↓ [ 100% ] 43/50 VUs  2m30s
+filtered_sorted_paginated   [   1% ] 01/50 VUs  0m02.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    2m28.0s
+autocomplete              • [   0% ] waiting    4m58.0s
+get_by_id                 • [   0% ] waiting    07m28.0s
+get_categories            • [   0% ] waiting    09m58.0s
+
+running (02m33.0s), 37/51 VUs, 111 complete and 0 interrupted iterations
+full_text_search          ↓ [ 100% ] 43/50 VUs  2m30s
+filtered_sorted_paginated   [   2% ] 01/50 VUs  0m03.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    2m27.0s
+autocomplete              • [   0% ] waiting    4m57.0s
+get_by_id                 • [   0% ] waiting    07m27.0s
+get_categories            • [   0% ] waiting    09m57.0s
+
+running (02m34.0s), 34/51 VUs, 114 complete and 0 interrupted iterations
+full_text_search          ↓ [ 100% ] 43/50 VUs  2m30s
+filtered_sorted_paginated   [   3% ] 01/50 VUs  0m04.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    2m26.0s
+autocomplete              • [   0% ] waiting    4m56.0s
+get_by_id                 • [   0% ] waiting    07m26.0s
+get_categories            • [   0% ] waiting    09m56.0s
+
+running (02m35.0s), 33/51 VUs, 115 complete and 0 interrupted iterations
+full_text_search          ↓ [ 100% ] 43/50 VUs  2m30s
+filtered_sorted_paginated   [   3% ] 01/50 VUs  0m05.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    2m25.0s
+autocomplete              • [   0% ] waiting    4m55.0s
+get_by_id                 • [   0% ] waiting    07m25.0s
+get_categories            • [   0% ] waiting    09m55.0s
+
+running (02m36.0s), 31/51 VUs, 117 complete and 0 interrupted iterations
+full_text_search          ↓ [ 100% ] 43/50 VUs  2m30s
+filtered_sorted_paginated   [   4% ] 01/50 VUs  0m06.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    2m24.0s
+autocomplete              • [   0% ] waiting    4m54.0s
+get_by_id                 • [   0% ] waiting    07m24.0s
+get_categories            • [   0% ] waiting    09m54.0s
+
+running (02m37.0s), 30/51 VUs, 118 complete and 0 interrupted iterations
+full_text_search          ↓ [ 100% ] 43/50 VUs  2m30s
+filtered_sorted_paginated   [   5% ] 01/50 VUs  0m07.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    2m23.0s
+autocomplete              • [   0% ] waiting    4m53.0s
+get_by_id                 • [   0% ] waiting    07m23.0s
+get_categories            • [   0% ] waiting    09m53.0s
+
+running (02m38.0s), 27/51 VUs, 121 complete and 0 interrupted iterations
+full_text_search          ↓ [ 100% ] 43/50 VUs  2m30s
+filtered_sorted_paginated   [   5% ] 01/50 VUs  0m08.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    2m22.0s
+autocomplete              • [   0% ] waiting    4m52.0s
+get_by_id                 • [   0% ] waiting    07m22.0s
+get_categories            • [   0% ] waiting    09m52.0s
+
+running (02m39.0s), 26/51 VUs, 122 complete and 0 interrupted iterations
+full_text_search          ↓ [ 100% ] 43/50 VUs  2m30s
+filtered_sorted_paginated   [   6% ] 01/50 VUs  0m09.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    2m21.0s
+autocomplete              • [   0% ] waiting    4m51.0s
+get_by_id                 • [   0% ] waiting    07m21.0s
+get_categories            • [   0% ] waiting    09m51.0s
+
+running (02m40.0s), 25/51 VUs, 123 complete and 0 interrupted iterations
+full_text_search          ↓ [ 100% ] 43/50 VUs  2m30s
+filtered_sorted_paginated   [   7% ] 01/50 VUs  0m10.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    2m20.0s
+autocomplete              • [   0% ] waiting    4m50.0s
+get_by_id                 • [   0% ] waiting    07m20.0s
+get_categories            • [   0% ] waiting    09m50.0s
+
+running (02m41.0s), 23/51 VUs, 125 complete and 0 interrupted iterations
+full_text_search          ↓ [ 100% ] 43/50 VUs  2m30s
+filtered_sorted_paginated   [   7% ] 01/50 VUs  0m11.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    2m19.0s
+autocomplete              • [   0% ] waiting    4m49.0s
+get_by_id                 • [   0% ] waiting    07m19.0s
+get_categories            • [   0% ] waiting    09m49.0s
+
+running (02m42.0s), 22/51 VUs, 126 complete and 0 interrupted iterations
+full_text_search          ↓ [ 100% ] 43/50 VUs  2m30s
+filtered_sorted_paginated   [   8% ] 01/50 VUs  0m12.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    2m18.0s
+autocomplete              • [   0% ] waiting    4m48.0s
+get_by_id                 • [   0% ] waiting    07m18.0s
+get_categories            • [   0% ] waiting    09m48.0s
+
+running (02m43.0s), 20/51 VUs, 128 complete and 0 interrupted iterations
+full_text_search          ↓ [ 100% ] 43/50 VUs  2m30s
+filtered_sorted_paginated   [   9% ] 01/50 VUs  0m13.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    2m17.0s
+autocomplete              • [   0% ] waiting    4m47.0s
+get_by_id                 • [   0% ] waiting    07m17.0s
+get_categories            • [   0% ] waiting    09m47.0s
+
+running (02m44.0s), 19/51 VUs, 129 complete and 0 interrupted iterations
+full_text_search          ↓ [ 100% ] 43/50 VUs  2m30s
+filtered_sorted_paginated   [   9% ] 01/50 VUs  0m14.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    2m16.0s
+autocomplete              • [   0% ] waiting    4m46.0s
+get_by_id                 • [   0% ] waiting    07m16.0s
+get_categories            • [   0% ] waiting    09m46.0s
+
+running (02m45.0s), 17/51 VUs, 131 complete and 0 interrupted iterations
+full_text_search          ↓ [ 100% ] 43/50 VUs  2m30s
+filtered_sorted_paginated   [  10% ] 01/50 VUs  0m15.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    2m15.0s
+autocomplete              • [   0% ] waiting    4m45.0s
+get_by_id                 • [   0% ] waiting    07m15.0s
+get_categories            • [   0% ] waiting    09m45.0s
+
+running (02m46.0s), 15/51 VUs, 133 complete and 0 interrupted iterations
+full_text_search          ↓ [ 100% ] 43/50 VUs  2m30s
+filtered_sorted_paginated   [  11% ] 01/50 VUs  0m16.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    2m14.0s
+autocomplete              • [   0% ] waiting    4m44.0s
+get_by_id                 • [   0% ] waiting    07m14.0s
+get_categories            • [   0% ] waiting    09m44.0s
+
+running (02m47.0s), 14/51 VUs, 134 complete and 0 interrupted iterations
+full_text_search          ↓ [ 100% ] 43/50 VUs  2m30s
+filtered_sorted_paginated   [  11% ] 01/50 VUs  0m17.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    2m13.0s
+autocomplete              • [   0% ] waiting    4m43.0s
+get_by_id                 • [   0% ] waiting    07m13.0s
+get_categories            • [   0% ] waiting    09m43.0s
+
+running (02m48.0s), 13/51 VUs, 135 complete and 0 interrupted iterations
+full_text_search          ↓ [ 100% ] 43/50 VUs  2m30s
+filtered_sorted_paginated   [  12% ] 01/50 VUs  0m18.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    2m12.0s
+autocomplete              • [   0% ] waiting    4m42.0s
+get_by_id                 • [   0% ] waiting    07m12.0s
+get_categories            • [   0% ] waiting    09m42.0s
+
+running (02m49.0s), 12/51 VUs, 137 complete and 0 interrupted iterations
+full_text_search          ↓ [ 100% ] 43/50 VUs  2m30s
+filtered_sorted_paginated   [  13% ] 02/50 VUs  0m19.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    2m11.0s
+autocomplete              • [   0% ] waiting    4m41.0s
+get_by_id                 • [   0% ] waiting    07m11.0s
+get_categories            • [   0% ] waiting    09m41.0s
+
+running (02m50.0s), 12/51 VUs, 137 complete and 0 interrupted iterations
+full_text_search          ↓ [ 100% ] 43/50 VUs  2m30s
+filtered_sorted_paginated   [  13% ] 02/50 VUs  0m20.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    2m10.0s
+autocomplete              • [   0% ] waiting    4m40.0s
+get_by_id                 • [   0% ] waiting    07m10.0s
+get_categories            • [   0% ] waiting    09m40.0s
+
+running (02m51.0s), 09/51 VUs, 140 complete and 0 interrupted iterations
+full_text_search          ↓ [ 100% ] 43/50 VUs  2m30s
+filtered_sorted_paginated   [  14% ] 02/50 VUs  0m21.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    2m09.0s
+autocomplete              • [   0% ] waiting    4m39.0s
+get_by_id                 • [   0% ] waiting    07m09.0s
+get_categories            • [   0% ] waiting    09m39.0s
+
+running (02m52.0s), 08/51 VUs, 142 complete and 0 interrupted iterations
+full_text_search          ↓ [ 100% ] 43/50 VUs  2m30s
+filtered_sorted_paginated   [  15% ] 03/50 VUs  0m22.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    2m08.0s
+autocomplete              • [   0% ] waiting    4m38.0s
+get_by_id                 • [   0% ] waiting    07m08.0s
+get_categories            • [   0% ] waiting    09m38.0s
+
+running (02m53.0s), 07/51 VUs, 143 complete and 0 interrupted iterations
+full_text_search          ↓ [ 100% ] 43/50 VUs  2m30s
+filtered_sorted_paginated   [  15% ] 03/50 VUs  0m23.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    2m07.0s
+autocomplete              • [   0% ] waiting    4m37.0s
+get_by_id                 • [   0% ] waiting    07m07.0s
+get_categories            • [   0% ] waiting    09m37.0s
+
+running (02m54.0s), 05/51 VUs, 145 complete and 0 interrupted iterations
+full_text_search          ↓ [ 100% ] 43/50 VUs  2m30s
+filtered_sorted_paginated   [  16% ] 03/50 VUs  0m24.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    2m06.0s
+autocomplete              • [   0% ] waiting    4m36.0s
+get_by_id                 • [   0% ] waiting    07m06.0s
+get_categories            • [   0% ] waiting    09m36.0s
+
+running (02m55.0s), 04/51 VUs, 145 complete and 1 interrupted iterations
+full_text_search          ↓ [ 100% ] 43/50 VUs  2m30s
+filtered_sorted_paginated   [  17% ] 03/50 VUs  0m25.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    2m05.0s
+autocomplete              • [   0% ] waiting    4m35.0s
+get_by_id                 • [   0% ] waiting    07m05.0s
+get_categories            • [   0% ] waiting    09m35.0s
+
+running (02m56.0s), 05/51 VUs, 145 complete and 1 interrupted iterations
+full_text_search          ↓ [ 100% ] 43/50 VUs  2m30s
+filtered_sorted_paginated   [  17% ] 04/50 VUs  0m26.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    2m04.0s
+autocomplete              • [   0% ] waiting    4m34.0s
+get_by_id                 • [   0% ] waiting    07m04.0s
+get_categories            • [   0% ] waiting    09m34.0s
+
+running (02m57.0s), 05/51 VUs, 145 complete and 1 interrupted iterations
+full_text_search          ↓ [ 100% ] 43/50 VUs  2m30s
+filtered_sorted_paginated   [  18% ] 04/50 VUs  0m27.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    2m03.0s
+autocomplete              • [   0% ] waiting    4m33.0s
+get_by_id                 • [   0% ] waiting    07m03.0s
+get_categories            • [   0% ] waiting    09m33.0s
+
+running (02m58.0s), 04/51 VUs, 146 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  19% ] 04/50 VUs  0m28.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    2m02.0s
+autocomplete              • [   0% ] waiting    4m32.0s
+get_by_id                 • [   0% ] waiting    07m02.0s
+get_categories            • [   0% ] waiting    09m32.0s
+
+running (02m59.0s), 05/51 VUs, 146 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  19% ] 05/50 VUs  0m29.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    2m01.0s
+autocomplete              • [   0% ] waiting    4m31.0s
+get_by_id                 • [   0% ] waiting    07m01.0s
+get_categories            • [   0% ] waiting    09m31.0s
+
+running (03m00.0s), 05/51 VUs, 146 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  20% ] 05/50 VUs  0m30.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    2m00.0s
+autocomplete              • [   0% ] waiting    4m30.0s
+get_by_id                 • [   0% ] waiting    07m00.0s
+get_categories            • [   0% ] waiting    09m30.0s
+
+running (03m01.0s), 05/51 VUs, 146 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  21% ] 05/50 VUs  0m31.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m59.0s
+autocomplete              • [   0% ] waiting    4m29.0s
+get_by_id                 • [   0% ] waiting    06m59.0s
+get_categories            • [   0% ] waiting    09m29.0s
+
+running (03m02.0s), 06/51 VUs, 147 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  21% ] 06/50 VUs  0m32.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m58.0s
+autocomplete              • [   0% ] waiting    4m28.0s
+get_by_id                 • [   0% ] waiting    06m58.0s
+get_categories            • [   0% ] waiting    09m28.0s
+
+running (03m03.0s), 06/51 VUs, 147 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  22% ] 06/50 VUs  0m33.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m57.0s
+autocomplete              • [   0% ] waiting    4m27.0s
+get_by_id                 • [   0% ] waiting    06m57.0s
+get_categories            • [   0% ] waiting    09m27.0s
+
+running (03m04.0s), 06/51 VUs, 147 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  23% ] 06/50 VUs  0m34.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m56.0s
+autocomplete              • [   0% ] waiting    4m26.0s
+get_by_id                 • [   0% ] waiting    06m56.0s
+get_categories            • [   0% ] waiting    09m26.0s
+
+running (03m05.0s), 06/51 VUs, 147 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  23% ] 06/50 VUs  0m35.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m55.0s
+autocomplete              • [   0% ] waiting    4m25.0s
+get_by_id                 • [   0% ] waiting    06m55.0s
+get_categories            • [   0% ] waiting    09m25.0s
+
+running (03m06.0s), 07/51 VUs, 147 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  24% ] 07/50 VUs  0m36.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m54.0s
+autocomplete              • [   0% ] waiting    4m24.0s
+get_by_id                 • [   0% ] waiting    06m54.0s
+get_categories            • [   0% ] waiting    09m24.0s
+
+running (03m07.0s), 07/51 VUs, 147 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  25% ] 07/50 VUs  0m37.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m53.0s
+autocomplete              • [   0% ] waiting    4m23.0s
+get_by_id                 • [   0% ] waiting    06m53.0s
+get_categories            • [   0% ] waiting    09m23.0s
+
+running (03m08.0s), 07/51 VUs, 147 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  25% ] 07/50 VUs  0m38.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m52.0s
+autocomplete              • [   0% ] waiting    4m22.0s
+get_by_id                 • [   0% ] waiting    06m52.0s
+get_categories            • [   0% ] waiting    09m22.0s
+
+running (03m09.0s), 08/51 VUs, 147 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  26% ] 08/50 VUs  0m39.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m51.0s
+autocomplete              • [   0% ] waiting    4m21.0s
+get_by_id                 • [   0% ] waiting    06m51.0s
+get_categories            • [   0% ] waiting    09m21.0s
+
+running (03m10.0s), 08/51 VUs, 147 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  27% ] 08/50 VUs  0m40.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m50.0s
+autocomplete              • [   0% ] waiting    4m20.0s
+get_by_id                 • [   0% ] waiting    06m50.0s
+get_categories            • [   0% ] waiting    09m20.0s
+
+running (03m11.0s), 08/51 VUs, 147 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  27% ] 08/50 VUs  0m41.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m49.0s
+autocomplete              • [   0% ] waiting    4m19.0s
+get_by_id                 • [   0% ] waiting    06m49.0s
+get_categories            • [   0% ] waiting    09m19.0s
+
+running (03m12.0s), 09/51 VUs, 147 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  28% ] 09/50 VUs  0m42.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m48.0s
+autocomplete              • [   0% ] waiting    4m18.0s
+get_by_id                 • [   0% ] waiting    06m48.0s
+get_categories            • [   0% ] waiting    09m18.0s
+
+running (03m13.0s), 09/51 VUs, 147 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  29% ] 09/50 VUs  0m43.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m47.0s
+autocomplete              • [   0% ] waiting    4m17.0s
+get_by_id                 • [   0% ] waiting    06m47.0s
+get_categories            • [   0% ] waiting    09m17.0s
+
+running (03m14.0s), 09/51 VUs, 147 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  29% ] 09/50 VUs  0m44.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m46.0s
+autocomplete              • [   0% ] waiting    4m16.0s
+get_by_id                 • [   0% ] waiting    06m46.0s
+get_categories            • [   0% ] waiting    09m16.0s
+
+running (03m15.0s), 09/51 VUs, 147 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  30% ] 09/50 VUs  0m45.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m45.0s
+autocomplete              • [   0% ] waiting    4m15.0s
+get_by_id                 • [   0% ] waiting    06m45.0s
+get_categories            • [   0% ] waiting    09m15.0s
+
+running (03m16.0s), 10/51 VUs, 147 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  31% ] 10/50 VUs  0m46.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m44.0s
+autocomplete              • [   0% ] waiting    4m14.0s
+get_by_id                 • [   0% ] waiting    06m44.0s
+get_categories            • [   0% ] waiting    09m14.0s
+
+running (03m17.0s), 10/51 VUs, 147 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  31% ] 10/50 VUs  0m47.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m43.0s
+autocomplete              • [   0% ] waiting    4m13.0s
+get_by_id                 • [   0% ] waiting    06m43.0s
+get_categories            • [   0% ] waiting    09m13.0s
+
+running (03m18.0s), 10/51 VUs, 147 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  32% ] 10/50 VUs  0m48.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m42.0s
+autocomplete              • [   0% ] waiting    4m12.0s
+get_by_id                 • [   0% ] waiting    06m42.0s
+get_categories            • [   0% ] waiting    09m12.0s
+
+running (03m19.0s), 10/51 VUs, 148 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  33% ] 10/50 VUs  0m49.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m41.0s
+autocomplete              • [   0% ] waiting    4m11.0s
+get_by_id                 • [   0% ] waiting    06m41.0s
+get_categories            • [   0% ] waiting    09m11.0s
+
+running (03m20.0s), 10/51 VUs, 148 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  33% ] 10/50 VUs  0m50.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m40.0s
+autocomplete              • [   0% ] waiting    4m10.0s
+get_by_id                 • [   0% ] waiting    06m40.0s
+get_categories            • [   0% ] waiting    09m10.0s
+
+running (03m21.0s), 10/51 VUs, 148 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  34% ] 10/50 VUs  0m51.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m39.0s
+autocomplete              • [   0% ] waiting    4m09.0s
+get_by_id                 • [   0% ] waiting    06m39.0s
+get_categories            • [   0% ] waiting    09m09.0s
+
+running (03m22.0s), 10/51 VUs, 148 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  35% ] 10/50 VUs  0m52.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m38.0s
+autocomplete              • [   0% ] waiting    4m08.0s
+get_by_id                 • [   0% ] waiting    06m38.0s
+get_categories            • [   0% ] waiting    09m08.0s
+
+running (03m23.0s), 10/51 VUs, 149 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  35% ] 10/50 VUs  0m53.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m37.0s
+autocomplete              • [   0% ] waiting    4m07.0s
+get_by_id                 • [   0% ] waiting    06m37.0s
+get_categories            • [   0% ] waiting    09m07.0s
+
+running (03m24.0s), 10/51 VUs, 149 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  36% ] 10/50 VUs  0m54.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m36.0s
+autocomplete              • [   0% ] waiting    4m06.0s
+get_by_id                 • [   0% ] waiting    06m36.0s
+get_categories            • [   0% ] waiting    09m06.0s
+
+running (03m25.0s), 10/51 VUs, 149 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  37% ] 10/50 VUs  0m55.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m35.0s
+autocomplete              • [   0% ] waiting    4m05.0s
+get_by_id                 • [   0% ] waiting    06m35.0s
+get_categories            • [   0% ] waiting    09m05.0s
+
+running (03m26.0s), 10/51 VUs, 150 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  37% ] 10/50 VUs  0m56.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m34.0s
+autocomplete              • [   0% ] waiting    4m04.0s
+get_by_id                 • [   0% ] waiting    06m34.0s
+get_categories            • [   0% ] waiting    09m04.0s
+
+running (03m27.0s), 10/51 VUs, 150 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  38% ] 10/50 VUs  0m57.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m33.0s
+autocomplete              • [   0% ] waiting    4m03.0s
+get_by_id                 • [   0% ] waiting    06m33.0s
+get_categories            • [   0% ] waiting    09m03.0s
+
+running (03m28.0s), 10/51 VUs, 150 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  39% ] 10/50 VUs  0m58.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m32.0s
+autocomplete              • [   0% ] waiting    4m02.0s
+get_by_id                 • [   0% ] waiting    06m32.0s
+get_categories            • [   0% ] waiting    09m02.0s
+
+running (03m29.0s), 10/51 VUs, 151 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  39% ] 10/50 VUs  0m59.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m31.0s
+autocomplete              • [   0% ] waiting    4m01.0s
+get_by_id                 • [   0% ] waiting    06m31.0s
+get_categories            • [   0% ] waiting    09m01.0s
+
+running (03m30.0s), 10/51 VUs, 151 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  40% ] 10/50 VUs  1m00.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m30.0s
+autocomplete              • [   0% ] waiting    4m00.0s
+get_by_id                 • [   0% ] waiting    06m30.0s
+get_categories            • [   0% ] waiting    09m00.0s
+
+running (03m31.0s), 10/51 VUs, 151 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  41% ] 10/50 VUs  1m01.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m29.0s
+autocomplete              • [   0% ] waiting    3m59.0s
+get_by_id                 • [   0% ] waiting    06m29.0s
+get_categories            • [   0% ] waiting    08m59.0s
+
+running (03m32.0s), 10/51 VUs, 151 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  41% ] 10/50 VUs  1m02.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m28.0s
+autocomplete              • [   0% ] waiting    3m58.0s
+get_by_id                 • [   0% ] waiting    06m28.0s
+get_categories            • [   0% ] waiting    08m58.0s
+
+running (03m33.0s), 10/51 VUs, 153 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  42% ] 10/50 VUs  1m03.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m27.0s
+autocomplete              • [   0% ] waiting    3m57.0s
+get_by_id                 • [   0% ] waiting    06m27.0s
+get_categories            • [   0% ] waiting    08m57.0s
+
+running (03m34.0s), 10/51 VUs, 153 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  43% ] 10/50 VUs  1m04.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m26.0s
+autocomplete              • [   0% ] waiting    3m56.0s
+get_by_id                 • [   0% ] waiting    06m26.0s
+get_categories            • [   0% ] waiting    08m56.0s
+
+running (03m35.0s), 10/51 VUs, 153 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  43% ] 10/50 VUs  1m05.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m25.0s
+autocomplete              • [   0% ] waiting    3m55.0s
+get_by_id                 • [   0% ] waiting    06m25.0s
+get_categories            • [   0% ] waiting    08m55.0s
+
+running (03m36.0s), 10/51 VUs, 154 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  44% ] 10/50 VUs  1m06.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m24.0s
+autocomplete              • [   0% ] waiting    3m54.0s
+get_by_id                 • [   0% ] waiting    06m24.0s
+get_categories            • [   0% ] waiting    08m54.0s
+
+running (03m37.0s), 10/51 VUs, 154 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  45% ] 10/50 VUs  1m07.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m23.0s
+autocomplete              • [   0% ] waiting    3m53.0s
+get_by_id                 • [   0% ] waiting    06m23.0s
+get_categories            • [   0% ] waiting    08m53.0s
+
+running (03m38.0s), 10/51 VUs, 154 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  45% ] 10/50 VUs  1m08.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m22.0s
+autocomplete              • [   0% ] waiting    3m52.0s
+get_by_id                 • [   0% ] waiting    06m22.0s
+get_categories            • [   0% ] waiting    08m52.0s
+
+running (03m39.0s), 10/51 VUs, 155 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  46% ] 10/50 VUs  1m09.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m21.0s
+autocomplete              • [   0% ] waiting    3m51.0s
+get_by_id                 • [   0% ] waiting    06m21.0s
+get_categories            • [   0% ] waiting    08m51.0s
+
+running (03m40.0s), 10/51 VUs, 155 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  47% ] 10/50 VUs  1m10.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m20.0s
+autocomplete              • [   0% ] waiting    3m50.0s
+get_by_id                 • [   0% ] waiting    06m20.0s
+get_categories            • [   0% ] waiting    08m50.0s
+
+running (03m41.0s), 10/51 VUs, 155 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  47% ] 10/50 VUs  1m11.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m19.0s
+autocomplete              • [   0% ] waiting    3m49.0s
+get_by_id                 • [   0% ] waiting    06m19.0s
+get_categories            • [   0% ] waiting    08m49.0s
+
+running (03m42.0s), 10/51 VUs, 155 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  48% ] 10/50 VUs  1m12.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m18.0s
+autocomplete              • [   0% ] waiting    3m48.0s
+get_by_id                 • [   0% ] waiting    06m18.0s
+get_categories            • [   0% ] waiting    08m48.0s
+
+running (03m43.0s), 10/51 VUs, 156 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  49% ] 10/50 VUs  1m13.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m17.0s
+autocomplete              • [   0% ] waiting    3m47.0s
+get_by_id                 • [   0% ] waiting    06m17.0s
+get_categories            • [   0% ] waiting    08m47.0s
+
+running (03m44.0s), 10/51 VUs, 156 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  49% ] 10/50 VUs  1m14.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m16.0s
+autocomplete              • [   0% ] waiting    3m46.0s
+get_by_id                 • [   0% ] waiting    06m16.0s
+get_categories            • [   0% ] waiting    08m46.0s
+
+running (03m45.0s), 10/51 VUs, 156 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  50% ] 10/50 VUs  1m15.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m15.0s
+autocomplete              • [   0% ] waiting    3m45.0s
+get_by_id                 • [   0% ] waiting    06m15.0s
+get_categories            • [   0% ] waiting    08m45.0s
+
+running (03m46.0s), 11/51 VUs, 157 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  51% ] 11/50 VUs  1m16.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m14.0s
+autocomplete              • [   0% ] waiting    3m44.0s
+get_by_id                 • [   0% ] waiting    06m14.0s
+get_categories            • [   0% ] waiting    08m44.0s
+
+running (03m47.0s), 12/51 VUs, 157 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  51% ] 12/50 VUs  1m17.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m13.0s
+autocomplete              • [   0% ] waiting    3m43.0s
+get_by_id                 • [   0% ] waiting    06m13.0s
+get_categories            • [   0% ] waiting    08m43.0s
+time="2026-03-12T13:22:02Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?categoryName=Electronics%20Accessories&minPrice=84&maxPrice=1217&sortBy=price&sortDir=asc&size=20&page=8\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (03m48.0s), 13/51 VUs, 158 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  52% ] 13/50 VUs  1m18.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m12.0s
+autocomplete              • [   0% ] waiting    3m42.0s
+get_by_id                 • [   0% ] waiting    06m12.0s
+get_categories            • [   0% ] waiting    08m42.0s
+time="2026-03-12T13:22:03Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?categoryName=Footwear&minPrice=518&maxPrice=2608&sortBy=price&sortDir=asc&size=20&page=2\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (03m49.0s), 15/51 VUs, 159 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  53% ] 15/50 VUs  1m19.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m11.0s
+autocomplete              • [   0% ] waiting    3m41.0s
+get_by_id                 • [   0% ] waiting    06m11.0s
+get_categories            • [   0% ] waiting    08m41.0s
+time="2026-03-12T13:22:04Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?categoryName=Footwear&minPrice=68&maxPrice=2318&sortBy=price&sortDir=desc&size=20&page=0\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (03m50.0s), 16/51 VUs, 160 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  53% ] 16/50 VUs  1m20.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m10.0s
+autocomplete              • [   0% ] waiting    3m40.0s
+get_by_id                 • [   0% ] waiting    06m10.0s
+get_categories            • [   0% ] waiting    08m40.0s
+time="2026-03-12T13:22:05Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?categoryName=Jewelry&minPrice=163&maxPrice=5406&sortBy=price&sortDir=desc&size=20&page=8\": dial tcp 172.20.150.69:80: connect: connection refused"
+time="2026-03-12T13:22:05Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?categoryName=Women's%20Clothing&minPrice=480&maxPrice=4171&sortBy=price&sortDir=desc&size=20&page=5\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (03m51.0s), 17/51 VUs, 162 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  54% ] 17/50 VUs  1m21.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m09.0s
+autocomplete              • [   0% ] waiting    3m39.0s
+get_by_id                 • [   0% ] waiting    06m09.0s
+get_categories            • [   0% ] waiting    08m39.0s
+time="2026-03-12T13:22:06Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?categoryName=Sports%20%26%20Outdoors&minPrice=420&maxPrice=1380&sortBy=price&sortDir=asc&size=20&page=8\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (03m52.0s), 19/51 VUs, 164 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  55% ] 19/50 VUs  1m22.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m08.0s
+autocomplete              • [   0% ] waiting    3m38.0s
+get_by_id                 • [   0% ] waiting    06m08.0s
+get_categories            • [   0% ] waiting    08m38.0s
+
+running (03m53.0s), 20/51 VUs, 165 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  55% ] 20/50 VUs  1m23.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m07.0s
+autocomplete              • [   0% ] waiting    3m37.0s
+get_by_id                 • [   0% ] waiting    06m07.0s
+get_categories            • [   0% ] waiting    08m37.0s
+
+running (03m54.0s), 21/51 VUs, 165 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  56% ] 21/50 VUs  1m24.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m06.0s
+autocomplete              • [   0% ] waiting    3m36.0s
+get_by_id                 • [   0% ] waiting    06m06.0s
+get_categories            • [   0% ] waiting    08m36.0s
+time="2026-03-12T13:22:09Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?categoryName=Women's%20Clothing&minPrice=263&maxPrice=3825&sortBy=price&sortDir=asc&size=20&page=0\": dial tcp 172.20.150.69:80: connect: connection refused"
+time="2026-03-12T13:22:10Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?categoryName=Kitchen%20%26%20Dining&minPrice=138&maxPrice=2631&sortBy=price&sortDir=asc&size=20&page=0\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (03m55.0s), 23/51 VUs, 166 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  57% ] 23/50 VUs  1m25.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m05.0s
+autocomplete              • [   0% ] waiting    3m35.0s
+get_by_id                 • [   0% ] waiting    06m05.0s
+get_categories            • [   0% ] waiting    08m35.0s
+time="2026-03-12T13:22:10Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?categoryName=Jewelry&minPrice=318&maxPrice=1508&sortBy=price&sortDir=asc&size=20&page=1\": dial tcp 172.20.150.69:80: connect: connection refused"
+time="2026-03-12T13:22:10Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?categoryName=Home%20Decor&minPrice=102&maxPrice=2645&sortBy=price&sortDir=asc&size=20&page=6\": dial tcp 172.20.150.69:80: connect: connection refused"
+time="2026-03-12T13:22:11Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?categoryName=Beauty%20%26%20Personal%20Care&minPrice=148&maxPrice=2777&sortBy=price&sortDir=desc&size=20&page=8\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (03m56.0s), 24/51 VUs, 168 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  57% ] 24/50 VUs  1m26.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m04.0s
+autocomplete              • [   0% ] waiting    3m34.0s
+get_by_id                 • [   0% ] waiting    06m04.0s
+get_categories            • [   0% ] waiting    08m34.0s
+time="2026-03-12T13:22:11Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?categoryName=Electronics%20Accessories&minPrice=77&maxPrice=2365&sortBy=price&sortDir=desc&size=20&page=3\": dial tcp 172.20.150.69:80: connect: connection refused"
+time="2026-03-12T13:22:11Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?categoryName=Jewelry&minPrice=165&maxPrice=3570&sortBy=price&sortDir=asc&size=20&page=9\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (03m57.0s), 25/51 VUs, 173 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  58% ] 25/50 VUs  1m27.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m03.0s
+autocomplete              • [   0% ] waiting    3m33.0s
+get_by_id                 • [   0% ] waiting    06m03.0s
+get_categories            • [   0% ] waiting    08m33.0s
+time="2026-03-12T13:22:12Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?categoryName=Furniture&minPrice=243&maxPrice=1744&sortBy=price&sortDir=asc&size=20&page=4\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (03m58.0s), 27/51 VUs, 174 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  59% ] 27/50 VUs  1m28.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m02.0s
+autocomplete              • [   0% ] waiting    3m32.0s
+get_by_id                 • [   0% ] waiting    06m02.0s
+get_categories            • [   0% ] waiting    08m32.0s
+time="2026-03-12T13:22:13Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?categoryName=Kitchen%20%26%20Dining&minPrice=297&maxPrice=1890&sortBy=price&sortDir=asc&size=20&page=0\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (03m59.0s), 28/51 VUs, 174 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  59% ] 28/50 VUs  1m29.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m01.0s
+autocomplete              • [   0% ] waiting    3m31.0s
+get_by_id                 • [   0% ] waiting    06m01.0s
+get_categories            • [   0% ] waiting    08m31.0s
+time="2026-03-12T13:22:14Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?categoryName=Men's%20Clothing&minPrice=115&maxPrice=1417&sortBy=price&sortDir=asc&size=20&page=3\": dial tcp 172.20.150.69:80: connect: connection refused"
+time="2026-03-12T13:22:14Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?categoryName=Furniture&minPrice=263&maxPrice=5389&sortBy=price&sortDir=desc&size=20&page=9\": dial tcp 172.20.150.69:80: connect: connection refused"
+time="2026-03-12T13:22:14Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?categoryName=Kitchen%20%26%20Dining&minPrice=105&maxPrice=2848&sortBy=price&sortDir=asc&size=20&page=5\": dial tcp 172.20.150.69:80: connect: connection refused"
+time="2026-03-12T13:22:15Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?categoryName=Furniture&minPrice=262&maxPrice=3338&sortBy=price&sortDir=asc&size=20&page=7\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (04m00.0s), 29/51 VUs, 178 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  60% ] 29/50 VUs  1m30.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    1m00.0s
+autocomplete              • [   0% ] waiting    3m30.0s
+get_by_id                 • [   0% ] waiting    06m00.0s
+get_categories            • [   0% ] waiting    08m30.0s
+time="2026-03-12T13:22:15Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?categoryName=Women's%20Clothing&minPrice=160&maxPrice=1657&sortBy=price&sortDir=desc&size=20&page=1\": dial tcp 172.20.150.69:80: connect: connection refused"
+time="2026-03-12T13:22:15Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?categoryName=Women's%20Clothing&minPrice=224&maxPrice=2823&sortBy=price&sortDir=asc&size=20&page=2\": dial tcp 172.20.150.69:80: connect: connection refused"
+time="2026-03-12T13:22:16Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?categoryName=Footwear&minPrice=429&maxPrice=4645&sortBy=price&sortDir=asc&size=20&page=2\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (04m01.0s), 31/51 VUs, 182 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  61% ] 31/50 VUs  1m31.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m59.0s
+autocomplete              • [   0% ] waiting    3m29.0s
+get_by_id                 • [   0% ] waiting    05m59.0s
+get_categories            • [   0% ] waiting    08m29.0s
+
+running (04m02.0s), 32/51 VUs, 183 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  61% ] 32/50 VUs  1m32.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m58.0s
+autocomplete              • [   0% ] waiting    3m28.0s
+get_by_id                 • [   0% ] waiting    05m58.0s
+get_categories            • [   0% ] waiting    08m28.0s
+
+running (04m03.0s), 33/51 VUs, 185 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  62% ] 33/50 VUs  1m33.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m57.0s
+autocomplete              • [   0% ] waiting    3m27.0s
+get_by_id                 • [   0% ] waiting    05m57.0s
+get_categories            • [   0% ] waiting    08m27.0s
+time="2026-03-12T13:22:18Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?categoryName=Jewelry&minPrice=368&maxPrice=4425&sortBy=price&sortDir=desc&size=20&page=0\": dial tcp 172.20.150.69:80: connect: connection refused"
+time="2026-03-12T13:22:18Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?categoryName=Men's%20Clothing&minPrice=390&maxPrice=3083&sortBy=price&sortDir=desc&size=20&page=9\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (04m04.0s), 35/51 VUs, 186 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  63% ] 35/50 VUs  1m34.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m56.0s
+autocomplete              • [   0% ] waiting    3m26.0s
+get_by_id                 • [   0% ] waiting    05m56.0s
+get_categories            • [   0% ] waiting    08m26.0s
+time="2026-03-12T13:22:19Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?categoryName=Jewelry&minPrice=388&maxPrice=1387&sortBy=price&sortDir=desc&size=20&page=4\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (04m05.0s), 36/51 VUs, 187 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  63% ] 36/50 VUs  1m35.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m55.0s
+autocomplete              • [   0% ] waiting    3m25.0s
+get_by_id                 • [   0% ] waiting    05m55.0s
+get_categories            • [   0% ] waiting    08m25.0s
+time="2026-03-12T13:22:20Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?categoryName=Jewelry&minPrice=333&maxPrice=1042&sortBy=price&sortDir=asc&size=20&page=3\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (04m06.0s), 37/51 VUs, 189 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  64% ] 37/50 VUs  1m36.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m54.0s
+autocomplete              • [   0% ] waiting    3m24.0s
+get_by_id                 • [   0% ] waiting    05m54.0s
+get_categories            • [   0% ] waiting    08m24.0s
+
+running (04m07.0s), 39/51 VUs, 190 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  65% ] 39/50 VUs  1m37.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m53.0s
+autocomplete              • [   0% ] waiting    3m23.0s
+get_by_id                 • [   0% ] waiting    05m53.0s
+get_categories            • [   0% ] waiting    08m23.0s
+
+running (04m08.0s), 40/51 VUs, 190 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  65% ] 40/50 VUs  1m38.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m52.0s
+autocomplete              • [   0% ] waiting    3m22.0s
+get_by_id                 • [   0% ] waiting    05m52.0s
+get_categories            • [   0% ] waiting    08m22.0s
+time="2026-03-12T13:22:23Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?categoryName=Home%20Decor&minPrice=114&maxPrice=1803&sortBy=price&sortDir=asc&size=20&page=0\": dial tcp 172.20.150.69:80: connect: connection refused"
+time="2026-03-12T13:22:24Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?categoryName=Jewelry&minPrice=326&maxPrice=1671&sortBy=price&sortDir=asc&size=20&page=6\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (04m09.0s), 41/51 VUs, 191 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  66% ] 41/50 VUs  1m39.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m51.0s
+autocomplete              • [   0% ] waiting    3m21.0s
+get_by_id                 • [   0% ] waiting    05m51.0s
+get_categories            • [   0% ] waiting    08m21.0s
+time="2026-03-12T13:22:24Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?categoryName=Footwear&minPrice=488&maxPrice=1040&sortBy=price&sortDir=asc&size=20&page=3\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (04m10.0s), 43/51 VUs, 194 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  67% ] 43/50 VUs  1m40.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m50.0s
+autocomplete              • [   0% ] waiting    3m20.0s
+get_by_id                 • [   0% ] waiting    05m50.0s
+get_categories            • [   0% ] waiting    08m20.0s
+time="2026-03-12T13:22:25Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?categoryName=Footwear&minPrice=103&maxPrice=1679&sortBy=price&sortDir=desc&size=20&page=8\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (04m11.0s), 44/51 VUs, 194 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  67% ] 44/50 VUs  1m41.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m49.0s
+autocomplete              • [   0% ] waiting    3m19.0s
+get_by_id                 • [   0% ] waiting    05m49.0s
+get_categories            • [   0% ] waiting    08m19.0s
+
+running (04m12.0s), 45/51 VUs, 195 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  68% ] 45/50 VUs  1m42.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m48.0s
+autocomplete              • [   0% ] waiting    3m18.0s
+get_by_id                 • [   0% ] waiting    05m48.0s
+get_categories            • [   0% ] waiting    08m18.0s
+
+running (04m13.0s), 47/51 VUs, 196 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  69% ] 47/50 VUs  1m43.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m47.0s
+autocomplete              • [   0% ] waiting    3m17.0s
+get_by_id                 • [   0% ] waiting    05m47.0s
+get_categories            • [   0% ] waiting    08m17.0s
+time="2026-03-12T13:22:28Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?categoryName=Furniture&minPrice=177&maxPrice=2475&sortBy=price&sortDir=asc&size=20&page=4\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (04m14.0s), 48/51 VUs, 196 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  69% ] 48/50 VUs  1m44.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m46.0s
+autocomplete              • [   0% ] waiting    3m16.0s
+get_by_id                 • [   0% ] waiting    05m46.0s
+get_categories            • [   0% ] waiting    08m16.0s
+time="2026-03-12T13:22:29Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?categoryName=Beauty%20%26%20Personal%20Care&minPrice=151&maxPrice=931&sortBy=price&sortDir=desc&size=20&page=6\": dial tcp 172.20.150.69:80: connect: connection refused"
+time="2026-03-12T13:22:29Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?categoryName=Beauty%20%26%20Personal%20Care&minPrice=239&maxPrice=3918&sortBy=price&sortDir=desc&size=20&page=3\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (04m15.0s), 49/51 VUs, 198 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  70% ] 49/50 VUs  1m45.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m45.0s
+autocomplete              • [   0% ] waiting    3m15.0s
+get_by_id                 • [   0% ] waiting    05m45.0s
+get_categories            • [   0% ] waiting    08m15.0s
+
+running (04m16.0s), 50/51 VUs, 199 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  71% ] 50/50 VUs  1m46.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m44.0s
+autocomplete              • [   0% ] waiting    3m14.0s
+get_by_id                 • [   0% ] waiting    05m44.0s
+get_categories            • [   0% ] waiting    08m14.0s
+
+running (04m17.0s), 50/51 VUs, 201 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  71% ] 50/50 VUs  1m47.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m43.0s
+autocomplete              • [   0% ] waiting    3m13.0s
+get_by_id                 • [   0% ] waiting    05m43.0s
+get_categories            • [   0% ] waiting    08m13.0s
+
+running (04m18.0s), 50/51 VUs, 202 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  72% ] 50/50 VUs  1m48.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m42.0s
+autocomplete              • [   0% ] waiting    3m12.0s
+get_by_id                 • [   0% ] waiting    05m42.0s
+get_categories            • [   0% ] waiting    08m12.0s
+
+running (04m19.0s), 50/51 VUs, 203 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  73% ] 50/50 VUs  1m49.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m41.0s
+autocomplete              • [   0% ] waiting    3m11.0s
+get_by_id                 • [   0% ] waiting    05m41.0s
+get_categories            • [   0% ] waiting    08m11.0s
+
+running (04m20.0s), 50/51 VUs, 206 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  73% ] 50/50 VUs  1m50.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m40.0s
+autocomplete              • [   0% ] waiting    3m10.0s
+get_by_id                 • [   0% ] waiting    05m40.0s
+get_categories            • [   0% ] waiting    08m10.0s
+
+running (04m21.0s), 50/51 VUs, 207 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  74% ] 50/50 VUs  1m51.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m39.0s
+autocomplete              • [   0% ] waiting    3m09.0s
+get_by_id                 • [   0% ] waiting    05m39.0s
+get_categories            • [   0% ] waiting    08m09.0s
+
+running (04m22.0s), 50/51 VUs, 208 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  75% ] 50/50 VUs  1m52.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m38.0s
+autocomplete              • [   0% ] waiting    3m08.0s
+get_by_id                 • [   0% ] waiting    05m38.0s
+get_categories            • [   0% ] waiting    08m08.0s
+
+running (04m23.0s), 50/51 VUs, 210 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  75% ] 50/50 VUs  1m53.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m37.0s
+autocomplete              • [   0% ] waiting    3m07.0s
+get_by_id                 • [   0% ] waiting    05m37.0s
+get_categories            • [   0% ] waiting    08m07.0s
+
+running (04m24.0s), 50/51 VUs, 213 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  76% ] 50/50 VUs  1m54.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m36.0s
+autocomplete              • [   0% ] waiting    3m06.0s
+get_by_id                 • [   0% ] waiting    05m36.0s
+get_categories            • [   0% ] waiting    08m06.0s
+
+running (04m25.0s), 50/51 VUs, 213 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  77% ] 50/50 VUs  1m55.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m35.0s
+autocomplete              • [   0% ] waiting    3m05.0s
+get_by_id                 • [   0% ] waiting    05m35.0s
+get_categories            • [   0% ] waiting    08m05.0s
+
+running (04m26.0s), 50/51 VUs, 214 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  77% ] 50/50 VUs  1m56.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m34.0s
+autocomplete              • [   0% ] waiting    3m04.0s
+get_by_id                 • [   0% ] waiting    05m34.0s
+get_categories            • [   0% ] waiting    08m04.0s
+
+running (04m27.0s), 50/51 VUs, 216 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  78% ] 50/50 VUs  1m57.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m33.0s
+autocomplete              • [   0% ] waiting    3m03.0s
+get_by_id                 • [   0% ] waiting    05m33.0s
+get_categories            • [   0% ] waiting    08m03.0s
+
+running (04m28.0s), 50/51 VUs, 218 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  79% ] 50/50 VUs  1m58.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m32.0s
+autocomplete              • [   0% ] waiting    3m02.0s
+get_by_id                 • [   0% ] waiting    05m32.0s
+get_categories            • [   0% ] waiting    08m02.0s
+
+running (04m29.0s), 50/51 VUs, 220 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  79% ] 50/50 VUs  1m59.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m31.0s
+autocomplete              • [   0% ] waiting    3m01.0s
+get_by_id                 • [   0% ] waiting    05m31.0s
+get_categories            • [   0% ] waiting    08m01.0s
+
+running (04m30.0s), 50/51 VUs, 221 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  80% ] 50/50 VUs  2m00.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m30.0s
+autocomplete              • [   0% ] waiting    3m00.0s
+get_by_id                 • [   0% ] waiting    05m30.0s
+get_categories            • [   0% ] waiting    08m00.0s
+
+running (04m31.0s), 50/51 VUs, 222 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  81% ] 50/50 VUs  2m01.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m29.0s
+autocomplete              • [   0% ] waiting    2m59.0s
+get_by_id                 • [   0% ] waiting    05m29.0s
+get_categories            • [   0% ] waiting    07m59.0s
+
+running (04m32.0s), 50/51 VUs, 225 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  81% ] 50/50 VUs  2m02.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m28.0s
+autocomplete              • [   0% ] waiting    2m58.0s
+get_by_id                 • [   0% ] waiting    05m28.0s
+get_categories            • [   0% ] waiting    07m58.0s
+
+running (04m33.0s), 50/51 VUs, 227 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  82% ] 50/50 VUs  2m03.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m27.0s
+autocomplete              • [   0% ] waiting    2m57.0s
+get_by_id                 • [   0% ] waiting    05m27.0s
+get_categories            • [   0% ] waiting    07m57.0s
+
+running (04m34.0s), 50/51 VUs, 229 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  83% ] 50/50 VUs  2m04.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m26.0s
+autocomplete              • [   0% ] waiting    2m56.0s
+get_by_id                 • [   0% ] waiting    05m26.0s
+get_categories            • [   0% ] waiting    07m56.0s
+
+running (04m35.0s), 50/51 VUs, 231 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  83% ] 50/50 VUs  2m05.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m25.0s
+autocomplete              • [   0% ] waiting    2m55.0s
+get_by_id                 • [   0% ] waiting    05m25.0s
+get_categories            • [   0% ] waiting    07m55.0s
+
+running (04m36.0s), 50/51 VUs, 232 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  84% ] 50/50 VUs  2m06.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m24.0s
+autocomplete              • [   0% ] waiting    2m54.0s
+get_by_id                 • [   0% ] waiting    05m24.0s
+get_categories            • [   0% ] waiting    07m54.0s
+
+running (04m37.0s), 50/51 VUs, 235 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  85% ] 50/50 VUs  2m07.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m23.0s
+autocomplete              • [   0% ] waiting    2m53.0s
+get_by_id                 • [   0% ] waiting    05m23.0s
+get_categories            • [   0% ] waiting    07m53.0s
+
+running (04m38.0s), 50/51 VUs, 236 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  85% ] 50/50 VUs  2m08.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m22.0s
+autocomplete              • [   0% ] waiting    2m52.0s
+get_by_id                 • [   0% ] waiting    05m22.0s
+get_categories            • [   0% ] waiting    07m52.0s
+
+running (04m39.0s), 50/51 VUs, 237 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  86% ] 50/50 VUs  2m09.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m21.0s
+autocomplete              • [   0% ] waiting    2m51.0s
+get_by_id                 • [   0% ] waiting    05m21.0s
+get_categories            • [   0% ] waiting    07m51.0s
+
+running (04m40.0s), 50/51 VUs, 239 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  87% ] 50/50 VUs  2m10.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m20.0s
+autocomplete              • [   0% ] waiting    2m50.0s
+get_by_id                 • [   0% ] waiting    05m20.0s
+get_categories            • [   0% ] waiting    07m50.0s
+
+running (04m41.0s), 50/51 VUs, 241 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  87% ] 50/50 VUs  2m11.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m19.0s
+autocomplete              • [   0% ] waiting    2m49.0s
+get_by_id                 • [   0% ] waiting    05m19.0s
+get_categories            • [   0% ] waiting    07m49.0s
+
+running (04m42.0s), 50/51 VUs, 243 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  88% ] 50/50 VUs  2m12.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m18.0s
+autocomplete              • [   0% ] waiting    2m48.0s
+get_by_id                 • [   0% ] waiting    05m18.0s
+get_categories            • [   0% ] waiting    07m48.0s
+
+running (04m43.0s), 50/51 VUs, 244 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  89% ] 50/50 VUs  2m13.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m17.0s
+autocomplete              • [   0% ] waiting    2m47.0s
+get_by_id                 • [   0% ] waiting    05m17.0s
+get_categories            • [   0% ] waiting    07m47.0s
+
+running (04m44.0s), 50/51 VUs, 246 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  89% ] 50/50 VUs  2m14.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m16.0s
+autocomplete              • [   0% ] waiting    2m46.0s
+get_by_id                 • [   0% ] waiting    05m16.0s
+get_categories            • [   0% ] waiting    07m46.0s
+
+running (04m45.0s), 50/51 VUs, 247 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  90% ] 50/50 VUs  2m15.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m15.0s
+autocomplete              • [   0% ] waiting    2m45.0s
+get_by_id                 • [   0% ] waiting    05m15.0s
+get_categories            • [   0% ] waiting    07m45.0s
+
+running (04m46.0s), 49/51 VUs, 249 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  91% ] 49/50 VUs  2m16.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m14.0s
+autocomplete              • [   0% ] waiting    2m44.0s
+get_by_id                 • [   0% ] waiting    05m14.0s
+get_categories            • [   0% ] waiting    07m44.0s
+
+running (04m47.0s), 49/51 VUs, 251 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  91% ] 49/50 VUs  2m17.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m13.0s
+autocomplete              • [   0% ] waiting    2m43.0s
+get_by_id                 • [   0% ] waiting    05m13.0s
+get_categories            • [   0% ] waiting    07m43.0s
+
+running (04m48.0s), 49/51 VUs, 252 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  92% ] 49/50 VUs  2m18.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m12.0s
+autocomplete              • [   0% ] waiting    2m42.0s
+get_by_id                 • [   0% ] waiting    05m12.0s
+get_categories            • [   0% ] waiting    07m42.0s
+
+running (04m49.0s), 49/51 VUs, 253 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  93% ] 49/50 VUs  2m19.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m11.0s
+autocomplete              • [   0% ] waiting    2m41.0s
+get_by_id                 • [   0% ] waiting    05m11.0s
+get_categories            • [   0% ] waiting    07m41.0s
+
+running (04m50.0s), 49/51 VUs, 255 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  93% ] 49/50 VUs  2m20.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m10.0s
+autocomplete              • [   0% ] waiting    2m40.0s
+get_by_id                 • [   0% ] waiting    05m10.0s
+get_categories            • [   0% ] waiting    07m40.0s
+
+running (04m51.0s), 49/51 VUs, 256 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  94% ] 49/50 VUs  2m21.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m09.0s
+autocomplete              • [   0% ] waiting    2m39.0s
+get_by_id                 • [   0% ] waiting    05m09.0s
+get_categories            • [   0% ] waiting    07m39.0s
+
+running (04m52.0s), 49/51 VUs, 257 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  95% ] 49/50 VUs  2m22.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m08.0s
+autocomplete              • [   0% ] waiting    2m38.0s
+get_by_id                 • [   0% ] waiting    05m08.0s
+get_categories            • [   0% ] waiting    07m38.0s
+
+running (04m53.0s), 49/51 VUs, 260 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  95% ] 49/50 VUs  2m23.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m07.0s
+autocomplete              • [   0% ] waiting    2m37.0s
+get_by_id                 • [   0% ] waiting    05m07.0s
+get_categories            • [   0% ] waiting    07m37.0s
+
+running (04m54.0s), 49/51 VUs, 262 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  96% ] 49/50 VUs  2m24.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m06.0s
+autocomplete              • [   0% ] waiting    2m36.0s
+get_by_id                 • [   0% ] waiting    05m06.0s
+get_categories            • [   0% ] waiting    07m36.0s
+
+running (04m55.0s), 48/51 VUs, 263 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  97% ] 48/50 VUs  2m25.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m05.0s
+autocomplete              • [   0% ] waiting    2m35.0s
+get_by_id                 • [   0% ] waiting    05m05.0s
+get_categories            • [   0% ] waiting    07m35.0s
+
+running (04m56.0s), 47/51 VUs, 264 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  97% ] 47/50 VUs  2m26.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m04.0s
+autocomplete              • [   0% ] waiting    2m34.0s
+get_by_id                 • [   0% ] waiting    05m04.0s
+get_categories            • [   0% ] waiting    07m34.0s
+
+running (04m57.0s), 47/51 VUs, 264 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  98% ] 47/50 VUs  2m27.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m03.0s
+autocomplete              • [   0% ] waiting    2m33.0s
+get_by_id                 • [   0% ] waiting    05m03.0s
+get_categories            • [   0% ] waiting    07m33.0s
+
+running (04m58.0s), 44/51 VUs, 268 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  99% ] 44/50 VUs  2m28.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m02.0s
+autocomplete              • [   0% ] waiting    2m32.0s
+get_by_id                 • [   0% ] waiting    05m02.0s
+get_categories            • [   0% ] waiting    07m32.0s
+
+running (04m59.0s), 42/51 VUs, 270 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [  99% ] 42/50 VUs  2m29.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m01.0s
+autocomplete              • [   0% ] waiting    2m31.0s
+get_by_id                 • [   0% ] waiting    05m01.0s
+get_categories            • [   0% ] waiting    07m31.0s
+
+running (05m00.0s), 42/51 VUs, 270 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated   [ 100% ] 42/50 VUs  2m30.0s/2m30.0s
+multi_field_search        • [   0% ] waiting    0m00.0s
+autocomplete              • [   0% ] waiting    2m30.0s
+get_by_id                 • [   0% ] waiting    05m00.0s
+get_categories            • [   0% ] waiting    07m30.0s
+
+running (05m01.0s), 42/51 VUs, 271 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ↓ [ 100% ] 42/50 VUs  2m30s
+multi_field_search          [   1% ] 01/50 VUs  0m01.0s/2m30.0s
+autocomplete              • [   0% ] waiting    2m29.0s
+get_by_id                 • [   0% ] waiting    04m59.0s
+get_categories            • [   0% ] waiting    07m29.0s
+
+running (05m02.0s), 39/51 VUs, 274 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ↓ [ 100% ] 42/50 VUs  2m30s
+multi_field_search          [   1% ] 01/50 VUs  0m02.0s/2m30.0s
+autocomplete              • [   0% ] waiting    2m28.0s
+get_by_id                 • [   0% ] waiting    04m58.0s
+get_categories            • [   0% ] waiting    07m28.0s
+
+running (05m03.0s), 37/51 VUs, 276 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ↓ [ 100% ] 42/50 VUs  2m30s
+multi_field_search          [   2% ] 01/50 VUs  0m03.0s/2m30.0s
+autocomplete              • [   0% ] waiting    2m27.0s
+get_by_id                 • [   0% ] waiting    04m57.0s
+get_categories            • [   0% ] waiting    07m27.0s
+
+running (05m04.0s), 34/51 VUs, 279 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ↓ [ 100% ] 42/50 VUs  2m30s
+multi_field_search          [   3% ] 01/50 VUs  0m04.0s/2m30.0s
+autocomplete              • [   0% ] waiting    2m26.0s
+get_by_id                 • [   0% ] waiting    04m56.0s
+get_categories            • [   0% ] waiting    07m26.0s
+
+running (05m05.0s), 33/51 VUs, 280 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ↓ [ 100% ] 42/50 VUs  2m30s
+multi_field_search          [   3% ] 01/50 VUs  0m05.0s/2m30.0s
+autocomplete              • [   0% ] waiting    2m25.0s
+get_by_id                 • [   0% ] waiting    04m55.0s
+get_categories            • [   0% ] waiting    07m25.0s
+
+running (05m06.0s), 32/51 VUs, 281 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ↓ [ 100% ] 42/50 VUs  2m30s
+multi_field_search          [   4% ] 01/50 VUs  0m06.0s/2m30.0s
+autocomplete              • [   0% ] waiting    2m24.0s
+get_by_id                 • [   0% ] waiting    04m54.0s
+get_categories            • [   0% ] waiting    07m24.0s
+
+running (05m07.0s), 30/51 VUs, 283 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ↓ [ 100% ] 42/50 VUs  2m30s
+multi_field_search          [   5% ] 01/50 VUs  0m07.0s/2m30.0s
+autocomplete              • [   0% ] waiting    2m23.0s
+get_by_id                 • [   0% ] waiting    04m53.0s
+get_categories            • [   0% ] waiting    07m23.0s
+
+running (05m08.0s), 27/51 VUs, 286 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ↓ [ 100% ] 42/50 VUs  2m30s
+multi_field_search          [   5% ] 01/50 VUs  0m08.0s/2m30.0s
+autocomplete              • [   0% ] waiting    2m22.0s
+get_by_id                 • [   0% ] waiting    04m52.0s
+get_categories            • [   0% ] waiting    07m22.0s
+
+running (05m09.0s), 26/51 VUs, 287 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ↓ [ 100% ] 42/50 VUs  2m30s
+multi_field_search          [   6% ] 01/50 VUs  0m09.0s/2m30.0s
+autocomplete              • [   0% ] waiting    2m21.0s
+get_by_id                 • [   0% ] waiting    04m51.0s
+get_categories            • [   0% ] waiting    07m21.0s
+
+running (05m10.0s), 26/51 VUs, 287 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ↓ [ 100% ] 42/50 VUs  2m30s
+multi_field_search          [   7% ] 01/50 VUs  0m10.0s/2m30.0s
+autocomplete              • [   0% ] waiting    2m20.0s
+get_by_id                 • [   0% ] waiting    04m50.0s
+get_categories            • [   0% ] waiting    07m20.0s
+
+running (05m11.0s), 22/51 VUs, 291 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ↓ [ 100% ] 42/50 VUs  2m30s
+multi_field_search          [   7% ] 01/50 VUs  0m11.0s/2m30.0s
+autocomplete              • [   0% ] waiting    2m19.0s
+get_by_id                 • [   0% ] waiting    04m49.0s
+get_categories            • [   0% ] waiting    07m19.0s
+
+running (05m12.0s), 22/51 VUs, 291 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ↓ [ 100% ] 42/50 VUs  2m30s
+multi_field_search          [   8% ] 01/50 VUs  0m12.0s/2m30.0s
+autocomplete              • [   0% ] waiting    2m18.0s
+get_by_id                 • [   0% ] waiting    04m48.0s
+get_categories            • [   0% ] waiting    07m18.0s
+
+running (05m13.0s), 20/51 VUs, 293 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ↓ [ 100% ] 42/50 VUs  2m30s
+multi_field_search          [   9% ] 01/50 VUs  0m13.0s/2m30.0s
+autocomplete              • [   0% ] waiting    2m17.0s
+get_by_id                 • [   0% ] waiting    04m47.0s
+get_categories            • [   0% ] waiting    07m17.0s
+
+running (05m14.0s), 17/51 VUs, 296 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ↓ [ 100% ] 42/50 VUs  2m30s
+multi_field_search          [   9% ] 01/50 VUs  0m14.0s/2m30.0s
+autocomplete              • [   0% ] waiting    2m16.0s
+get_by_id                 • [   0% ] waiting    04m46.0s
+get_categories            • [   0% ] waiting    07m16.0s
+
+running (05m15.0s), 17/51 VUs, 296 complete and 1 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ↓ [ 100% ] 42/50 VUs  2m30s
+multi_field_search          [  10% ] 01/50 VUs  0m15.0s/2m30.0s
+autocomplete              • [   0% ] waiting    2m15.0s
+get_by_id                 • [   0% ] waiting    04m45.0s
+get_categories            • [   0% ] waiting    07m15.0s
+
+running (05m16.0s), 15/51 VUs, 297 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ↓ [ 100% ] 42/50 VUs  2m30s
+multi_field_search          [  11% ] 01/50 VUs  0m16.0s/2m30.0s
+autocomplete              • [   0% ] waiting    2m14.0s
+get_by_id                 • [   0% ] waiting    04m44.0s
+get_categories            • [   0% ] waiting    07m14.0s
+
+running (05m17.0s), 15/51 VUs, 297 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ↓ [ 100% ] 42/50 VUs  2m30s
+multi_field_search          [  11% ] 01/50 VUs  0m17.0s/2m30.0s
+autocomplete              • [   0% ] waiting    2m13.0s
+get_by_id                 • [   0% ] waiting    04m43.0s
+get_categories            • [   0% ] waiting    07m13.0s
+
+running (05m18.0s), 13/51 VUs, 299 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ↓ [ 100% ] 42/50 VUs  2m30s
+multi_field_search          [  12% ] 01/50 VUs  0m18.0s/2m30.0s
+autocomplete              • [   0% ] waiting    2m12.0s
+get_by_id                 • [   0% ] waiting    04m42.0s
+get_categories            • [   0% ] waiting    07m12.0s
+
+running (05m19.0s), 13/51 VUs, 300 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ↓ [ 100% ] 42/50 VUs  2m30s
+multi_field_search          [  13% ] 02/50 VUs  0m19.0s/2m30.0s
+autocomplete              • [   0% ] waiting    2m11.0s
+get_by_id                 • [   0% ] waiting    04m41.0s
+get_categories            • [   0% ] waiting    07m11.0s
+
+running (05m20.0s), 12/51 VUs, 301 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ↓ [ 100% ] 42/50 VUs  2m30s
+multi_field_search          [  13% ] 02/50 VUs  0m20.0s/2m30.0s
+autocomplete              • [   0% ] waiting    2m10.0s
+get_by_id                 • [   0% ] waiting    04m40.0s
+get_categories            • [   0% ] waiting    07m10.0s
+
+running (05m21.0s), 09/51 VUs, 304 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ↓ [ 100% ] 42/50 VUs  2m30s
+multi_field_search          [  14% ] 02/50 VUs  0m21.0s/2m30.0s
+autocomplete              • [   0% ] waiting    2m09.0s
+get_by_id                 • [   0% ] waiting    04m39.0s
+get_categories            • [   0% ] waiting    07m09.0s
+
+running (05m22.0s), 09/51 VUs, 305 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ↓ [ 100% ] 42/50 VUs  2m30s
+multi_field_search          [  15% ] 03/50 VUs  0m22.0s/2m30.0s
+autocomplete              • [   0% ] waiting    2m08.0s
+get_by_id                 • [   0% ] waiting    04m38.0s
+get_categories            • [   0% ] waiting    07m08.0s
+
+running (05m23.0s), 08/51 VUs, 306 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ↓ [ 100% ] 42/50 VUs  2m30s
+multi_field_search          [  15% ] 03/50 VUs  0m23.0s/2m30.0s
+autocomplete              • [   0% ] waiting    2m07.0s
+get_by_id                 • [   0% ] waiting    04m37.0s
+get_categories            • [   0% ] waiting    07m07.0s
+
+running (05m24.0s), 06/51 VUs, 308 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ↓ [ 100% ] 42/50 VUs  2m30s
+multi_field_search          [  16% ] 03/50 VUs  0m24.0s/2m30.0s
+autocomplete              • [   0% ] waiting    2m06.0s
+get_by_id                 • [   0% ] waiting    04m36.0s
+get_categories            • [   0% ] waiting    07m06.0s
+
+running (05m25.0s), 04/51 VUs, 310 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ↓ [ 100% ] 42/50 VUs  2m30s
+multi_field_search          [  17% ] 03/50 VUs  0m25.0s/2m30.0s
+autocomplete              • [   0% ] waiting    2m05.0s
+get_by_id                 • [   0% ] waiting    04m35.0s
+get_categories            • [   0% ] waiting    07m05.0s
+
+running (05m26.0s), 05/51 VUs, 310 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ↓ [ 100% ] 42/50 VUs  2m30s
+multi_field_search          [  17% ] 04/50 VUs  0m26.0s/2m30.0s
+autocomplete              • [   0% ] waiting    2m04.0s
+get_by_id                 • [   0% ] waiting    04m34.0s
+get_categories            • [   0% ] waiting    07m04.0s
+
+running (05m27.0s), 05/51 VUs, 310 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ↓ [ 100% ] 42/50 VUs  2m30s
+multi_field_search          [  18% ] 04/50 VUs  0m27.0s/2m30.0s
+autocomplete              • [   0% ] waiting    2m03.0s
+get_by_id                 • [   0% ] waiting    04m33.0s
+get_categories            • [   0% ] waiting    07m03.0s
+
+running (05m28.0s), 04/51 VUs, 311 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  19% ] 04/50 VUs  0m28.0s/2m30.0s
+autocomplete              • [   0% ] waiting    2m02.0s
+get_by_id                 • [   0% ] waiting    04m32.0s
+get_categories            • [   0% ] waiting    07m02.0s
+
+running (05m29.0s), 05/51 VUs, 311 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  19% ] 05/50 VUs  0m29.0s/2m30.0s
+autocomplete              • [   0% ] waiting    2m01.0s
+get_by_id                 • [   0% ] waiting    04m31.0s
+get_categories            • [   0% ] waiting    07m01.0s
+
+running (05m30.0s), 05/51 VUs, 311 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  20% ] 05/50 VUs  0m30.0s/2m30.0s
+autocomplete              • [   0% ] waiting    2m00.0s
+get_by_id                 • [   0% ] waiting    04m30.0s
+get_categories            • [   0% ] waiting    07m00.0s
+
+running (05m31.0s), 05/51 VUs, 312 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  21% ] 05/50 VUs  0m31.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m59.0s
+get_by_id                 • [   0% ] waiting    04m29.0s
+get_categories            • [   0% ] waiting    06m59.0s
+
+running (05m32.0s), 06/51 VUs, 312 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  21% ] 06/50 VUs  0m32.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m58.0s
+get_by_id                 • [   0% ] waiting    04m28.0s
+get_categories            • [   0% ] waiting    06m58.0s
+
+running (05m33.0s), 06/51 VUs, 312 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  22% ] 06/50 VUs  0m33.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m57.0s
+get_by_id                 • [   0% ] waiting    04m27.0s
+get_categories            • [   0% ] waiting    06m57.0s
+
+running (05m34.0s), 06/51 VUs, 312 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  23% ] 06/50 VUs  0m34.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m56.0s
+get_by_id                 • [   0% ] waiting    04m26.0s
+get_categories            • [   0% ] waiting    06m56.0s
+
+running (05m35.0s), 06/51 VUs, 312 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  23% ] 06/50 VUs  0m35.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m55.0s
+get_by_id                 • [   0% ] waiting    04m25.0s
+get_categories            • [   0% ] waiting    06m55.0s
+
+running (05m36.0s), 07/51 VUs, 312 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  24% ] 07/50 VUs  0m36.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m54.0s
+get_by_id                 • [   0% ] waiting    04m24.0s
+get_categories            • [   0% ] waiting    06m54.0s
+
+running (05m37.0s), 07/51 VUs, 312 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  25% ] 07/50 VUs  0m37.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m53.0s
+get_by_id                 • [   0% ] waiting    04m23.0s
+get_categories            • [   0% ] waiting    06m53.0s
+
+running (05m38.0s), 07/51 VUs, 312 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  25% ] 07/50 VUs  0m38.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m52.0s
+get_by_id                 • [   0% ] waiting    04m22.0s
+get_categories            • [   0% ] waiting    06m52.0s
+
+running (05m39.0s), 08/51 VUs, 312 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  26% ] 08/50 VUs  0m39.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m51.0s
+get_by_id                 • [   0% ] waiting    04m21.0s
+get_categories            • [   0% ] waiting    06m51.0s
+
+running (05m40.0s), 08/51 VUs, 312 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  27% ] 08/50 VUs  0m40.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m50.0s
+get_by_id                 • [   0% ] waiting    04m20.0s
+get_categories            • [   0% ] waiting    06m50.0s
+
+running (05m41.0s), 08/51 VUs, 312 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  27% ] 08/50 VUs  0m41.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m49.0s
+get_by_id                 • [   0% ] waiting    04m19.0s
+get_categories            • [   0% ] waiting    06m49.0s
+
+running (05m42.0s), 09/51 VUs, 312 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  28% ] 09/50 VUs  0m42.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m48.0s
+get_by_id                 • [   0% ] waiting    04m18.0s
+get_categories            • [   0% ] waiting    06m48.0s
+
+running (05m43.0s), 09/51 VUs, 312 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  29% ] 09/50 VUs  0m43.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m47.0s
+get_by_id                 • [   0% ] waiting    04m17.0s
+get_categories            • [   0% ] waiting    06m47.0s
+
+running (05m44.0s), 09/51 VUs, 312 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  29% ] 09/50 VUs  0m44.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m46.0s
+get_by_id                 • [   0% ] waiting    04m16.0s
+get_categories            • [   0% ] waiting    06m46.0s
+
+running (05m45.0s), 09/51 VUs, 312 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  30% ] 09/50 VUs  0m45.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m45.0s
+get_by_id                 • [   0% ] waiting    04m15.0s
+get_categories            • [   0% ] waiting    06m45.0s
+
+running (05m46.0s), 10/51 VUs, 312 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  31% ] 10/50 VUs  0m46.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m44.0s
+get_by_id                 • [   0% ] waiting    04m14.0s
+get_categories            • [   0% ] waiting    06m44.0s
+
+running (05m47.0s), 10/51 VUs, 312 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  31% ] 10/50 VUs  0m47.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m43.0s
+get_by_id                 • [   0% ] waiting    04m13.0s
+get_categories            • [   0% ] waiting    06m43.0s
+
+running (05m48.0s), 10/51 VUs, 312 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  32% ] 10/50 VUs  0m48.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m42.0s
+get_by_id                 • [   0% ] waiting    04m12.0s
+get_categories            • [   0% ] waiting    06m42.0s
+
+running (05m49.0s), 10/51 VUs, 313 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  33% ] 10/50 VUs  0m49.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m41.0s
+get_by_id                 • [   0% ] waiting    04m11.0s
+get_categories            • [   0% ] waiting    06m41.0s
+
+running (05m50.0s), 10/51 VUs, 313 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  33% ] 10/50 VUs  0m50.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m40.0s
+get_by_id                 • [   0% ] waiting    04m10.0s
+get_categories            • [   0% ] waiting    06m40.0s
+
+running (05m51.0s), 10/51 VUs, 313 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  34% ] 10/50 VUs  0m51.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m39.0s
+get_by_id                 • [   0% ] waiting    04m09.0s
+get_categories            • [   0% ] waiting    06m39.0s
+
+running (05m52.0s), 10/51 VUs, 313 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  35% ] 10/50 VUs  0m52.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m38.0s
+get_by_id                 • [   0% ] waiting    04m08.0s
+get_categories            • [   0% ] waiting    06m38.0s
+
+running (05m53.0s), 10/51 VUs, 314 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  35% ] 10/50 VUs  0m53.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m37.0s
+get_by_id                 • [   0% ] waiting    04m07.0s
+get_categories            • [   0% ] waiting    06m37.0s
+
+running (05m54.0s), 10/51 VUs, 314 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  36% ] 10/50 VUs  0m54.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m36.0s
+get_by_id                 • [   0% ] waiting    04m06.0s
+get_categories            • [   0% ] waiting    06m36.0s
+
+running (05m55.0s), 10/51 VUs, 314 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  37% ] 10/50 VUs  0m55.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m35.0s
+get_by_id                 • [   0% ] waiting    04m05.0s
+get_categories            • [   0% ] waiting    06m35.0s
+
+running (05m56.0s), 10/51 VUs, 315 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  37% ] 10/50 VUs  0m56.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m34.0s
+get_by_id                 • [   0% ] waiting    04m04.0s
+get_categories            • [   0% ] waiting    06m34.0s
+
+running (05m57.0s), 10/51 VUs, 315 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  38% ] 10/50 VUs  0m57.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m33.0s
+get_by_id                 • [   0% ] waiting    04m03.0s
+get_categories            • [   0% ] waiting    06m33.0s
+
+running (05m58.0s), 10/51 VUs, 315 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  39% ] 10/50 VUs  0m58.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m32.0s
+get_by_id                 • [   0% ] waiting    04m02.0s
+get_categories            • [   0% ] waiting    06m32.0s
+
+running (05m59.0s), 10/51 VUs, 316 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  39% ] 10/50 VUs  0m59.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m31.0s
+get_by_id                 • [   0% ] waiting    04m01.0s
+get_categories            • [   0% ] waiting    06m31.0s
+
+running (06m00.0s), 10/51 VUs, 316 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  40% ] 10/50 VUs  1m00.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m30.0s
+get_by_id                 • [   0% ] waiting    04m00.0s
+get_categories            • [   0% ] waiting    06m30.0s
+
+running (06m01.0s), 10/51 VUs, 316 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  41% ] 10/50 VUs  1m01.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m29.0s
+get_by_id                 • [   0% ] waiting    03m59.0s
+get_categories            • [   0% ] waiting    06m29.0s
+
+running (06m02.0s), 10/51 VUs, 317 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  41% ] 10/50 VUs  1m02.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m28.0s
+get_by_id                 • [   0% ] waiting    03m58.0s
+get_categories            • [   0% ] waiting    06m28.0s
+
+running (06m03.0s), 10/51 VUs, 318 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  42% ] 10/50 VUs  1m03.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m27.0s
+get_by_id                 • [   0% ] waiting    03m57.0s
+get_categories            • [   0% ] waiting    06m27.0s
+
+running (06m04.0s), 10/51 VUs, 318 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  43% ] 10/50 VUs  1m04.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m26.0s
+get_by_id                 • [   0% ] waiting    03m56.0s
+get_categories            • [   0% ] waiting    06m26.0s
+
+running (06m05.0s), 10/51 VUs, 318 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  43% ] 10/50 VUs  1m05.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m25.0s
+get_by_id                 • [   0% ] waiting    03m55.0s
+get_categories            • [   0% ] waiting    06m25.0s
+
+running (06m06.0s), 10/51 VUs, 318 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  44% ] 10/50 VUs  1m06.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m24.0s
+get_by_id                 • [   0% ] waiting    03m54.0s
+get_categories            • [   0% ] waiting    06m24.0s
+
+running (06m07.0s), 10/51 VUs, 318 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  45% ] 10/50 VUs  1m07.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m23.0s
+get_by_id                 • [   0% ] waiting    03m53.0s
+get_categories            • [   0% ] waiting    06m23.0s
+
+running (06m08.0s), 10/51 VUs, 318 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  45% ] 10/50 VUs  1m08.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m22.0s
+get_by_id                 • [   0% ] waiting    03m52.0s
+get_categories            • [   0% ] waiting    06m22.0s
+
+running (06m09.0s), 10/51 VUs, 319 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  46% ] 10/50 VUs  1m09.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m21.0s
+get_by_id                 • [   0% ] waiting    03m51.0s
+get_categories            • [   0% ] waiting    06m21.0s
+
+running (06m10.0s), 10/51 VUs, 319 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  47% ] 10/50 VUs  1m10.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m20.0s
+get_by_id                 • [   0% ] waiting    03m50.0s
+get_categories            • [   0% ] waiting    06m20.0s
+
+running (06m11.0s), 10/51 VUs, 319 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  47% ] 10/50 VUs  1m11.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m19.0s
+get_by_id                 • [   0% ] waiting    03m49.0s
+get_categories            • [   0% ] waiting    06m19.0s
+
+running (06m12.0s), 10/51 VUs, 319 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  48% ] 10/50 VUs  1m12.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m18.0s
+get_by_id                 • [   0% ] waiting    03m48.0s
+get_categories            • [   0% ] waiting    06m18.0s
+
+running (06m13.0s), 10/51 VUs, 320 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  49% ] 10/50 VUs  1m13.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m17.0s
+get_by_id                 • [   0% ] waiting    03m47.0s
+get_categories            • [   0% ] waiting    06m17.0s
+
+running (06m14.0s), 10/51 VUs, 320 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  49% ] 10/50 VUs  1m14.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m16.0s
+get_by_id                 • [   0% ] waiting    03m46.0s
+get_categories            • [   0% ] waiting    06m16.0s
+
+running (06m15.0s), 10/51 VUs, 320 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  50% ] 10/50 VUs  1m15.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m15.0s
+get_by_id                 • [   0% ] waiting    03m45.0s
+get_categories            • [   0% ] waiting    06m15.0s
+
+running (06m16.0s), 11/51 VUs, 321 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  51% ] 11/50 VUs  1m16.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m14.0s
+get_by_id                 • [   0% ] waiting    03m44.0s
+get_categories            • [   0% ] waiting    06m14.0s
+time="2026-03-12T13:24:31Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=cotton&categoryName=Home%20Decor&size=20\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (06m17.0s), 12/51 VUs, 321 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  51% ] 12/50 VUs  1m17.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m13.0s
+get_by_id                 • [   0% ] waiting    03m43.0s
+get_categories            • [   0% ] waiting    06m13.0s
+time="2026-03-12T13:24:32Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=copper&categoryName=Men's%20Clothing&size=20\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (06m18.0s), 13/51 VUs, 323 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  52% ] 13/50 VUs  1m18.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m12.0s
+get_by_id                 • [   0% ] waiting    03m42.0s
+get_categories            • [   0% ] waiting    06m12.0s
+time="2026-03-12T13:24:34Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=wool&categoryName=Beauty%20%26%20Personal%20Care&size=20\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (06m19.0s), 15/51 VUs, 323 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  53% ] 15/50 VUs  1m19.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m11.0s
+get_by_id                 • [   0% ] waiting    03m41.0s
+get_categories            • [   0% ] waiting    06m11.0s
+time="2026-03-12T13:24:34Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=marble&categoryName=Furniture&size=20\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (06m20.0s), 16/51 VUs, 325 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  53% ] 16/50 VUs  1m20.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m10.0s
+get_by_id                 • [   0% ] waiting    03m40.0s
+get_categories            • [   0% ] waiting    06m10.0s
+time="2026-03-12T13:24:35Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=marble&categoryName=Footwear&size=20\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (06m21.0s), 17/51 VUs, 327 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  54% ] 17/50 VUs  1m21.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m09.0s
+get_by_id                 • [   0% ] waiting    03m39.0s
+get_categories            • [   0% ] waiting    06m09.0s
+
+running (06m22.0s), 19/51 VUs, 327 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  55% ] 19/50 VUs  1m22.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m08.0s
+get_by_id                 • [   0% ] waiting    03m38.0s
+get_categories            • [   0% ] waiting    06m08.0s
+time="2026-03-12T13:24:37Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=steel&categoryName=Home%20Decor&size=20\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (06m23.0s), 20/51 VUs, 328 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  55% ] 20/50 VUs  1m23.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m07.0s
+get_by_id                 • [   0% ] waiting    03m37.0s
+get_categories            • [   0% ] waiting    06m07.0s
+
+running (06m24.0s), 21/51 VUs, 329 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  56% ] 21/50 VUs  1m24.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m06.0s
+get_by_id                 • [   0% ] waiting    03m36.0s
+get_categories            • [   0% ] waiting    06m06.0s
+time="2026-03-12T13:24:40Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=copper&categoryName=Home%20Decor&size=20\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (06m25.0s), 23/51 VUs, 329 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  57% ] 23/50 VUs  1m25.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m05.0s
+get_by_id                 • [   0% ] waiting    03m35.0s
+get_categories            • [   0% ] waiting    06m05.0s
+
+running (06m26.0s), 24/51 VUs, 330 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  57% ] 24/50 VUs  1m26.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m04.0s
+get_by_id                 • [   0% ] waiting    03m34.0s
+get_categories            • [   0% ] waiting    06m04.0s
+
+running (06m27.0s), 25/51 VUs, 331 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  58% ] 25/50 VUs  1m27.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m03.0s
+get_by_id                 • [   0% ] waiting    03m33.0s
+get_categories            • [   0% ] waiting    06m03.0s
+
+running (06m28.0s), 27/51 VUs, 331 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  59% ] 27/50 VUs  1m28.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m02.0s
+get_by_id                 • [   0% ] waiting    03m32.0s
+get_categories            • [   0% ] waiting    06m02.0s
+
+running (06m29.0s), 28/51 VUs, 331 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  59% ] 28/50 VUs  1m29.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m01.0s
+get_by_id                 • [   0% ] waiting    03m31.0s
+get_categories            • [   0% ] waiting    06m01.0s
+
+running (06m30.0s), 29/51 VUs, 332 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  60% ] 29/50 VUs  1m30.0s/2m30.0s
+autocomplete              • [   0% ] waiting    1m00.0s
+get_by_id                 • [   0% ] waiting    03m30.0s
+get_categories            • [   0% ] waiting    06m00.0s
+time="2026-03-12T13:24:46Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=marble&categoryName=Home%20Decor&size=20\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (06m31.0s), 31/51 VUs, 332 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  61% ] 31/50 VUs  1m31.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m59.0s
+get_by_id                 • [   0% ] waiting    03m29.0s
+get_categories            • [   0% ] waiting    05m59.0s
+
+running (06m32.0s), 32/51 VUs, 334 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  61% ] 32/50 VUs  1m32.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m58.0s
+get_by_id                 • [   0% ] waiting    03m28.0s
+get_categories            • [   0% ] waiting    05m58.0s
+time="2026-03-12T13:24:47Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=copper&categoryName=Women's%20Clothing&size=20\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (06m33.0s), 33/51 VUs, 336 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  62% ] 33/50 VUs  1m33.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m57.0s
+get_by_id                 • [   0% ] waiting    03m27.0s
+get_categories            • [   0% ] waiting    05m57.0s
+
+running (06m34.0s), 35/51 VUs, 336 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  63% ] 35/50 VUs  1m34.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m56.0s
+get_by_id                 • [   0% ] waiting    03m26.0s
+get_categories            • [   0% ] waiting    05m56.0s
+
+running (06m35.0s), 36/51 VUs, 336 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  63% ] 36/50 VUs  1m35.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m55.0s
+get_by_id                 • [   0% ] waiting    03m25.0s
+get_categories            • [   0% ] waiting    05m55.0s
+time="2026-03-12T13:24:50Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=canvas&categoryName=Footwear&size=20\": request timeout"
+time="2026-03-12T13:24:50Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=wool&categoryName=Footwear&size=20\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (06m36.0s), 37/51 VUs, 337 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  64% ] 37/50 VUs  1m36.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m54.0s
+get_by_id                 • [   0% ] waiting    03m24.0s
+get_categories            • [   0% ] waiting    05m54.0s
+
+running (06m37.0s), 39/51 VUs, 338 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  65% ] 39/50 VUs  1m37.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m53.0s
+get_by_id                 • [   0% ] waiting    03m23.0s
+get_categories            • [   0% ] waiting    05m53.0s
+
+running (06m38.0s), 40/51 VUs, 338 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  65% ] 40/50 VUs  1m38.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m52.0s
+get_by_id                 • [   0% ] waiting    03m22.0s
+get_categories            • [   0% ] waiting    05m52.0s
+time="2026-03-12T13:24:53Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=velvet&categoryName=Furniture&size=20\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (06m39.0s), 41/51 VUs, 339 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  66% ] 41/50 VUs  1m39.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m51.0s
+get_by_id                 • [   0% ] waiting    03m21.0s
+get_categories            • [   0% ] waiting    05m51.0s
+time="2026-03-12T13:24:54Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=bamboo&categoryName=Home%20Decor&size=20\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (06m40.0s), 43/51 VUs, 341 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  67% ] 43/50 VUs  1m40.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m50.0s
+get_by_id                 • [   0% ] waiting    03m20.0s
+get_categories            • [   0% ] waiting    05m50.0s
+
+running (06m41.0s), 44/51 VUs, 341 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  67% ] 44/50 VUs  1m41.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m49.0s
+get_by_id                 • [   0% ] waiting    03m19.0s
+get_categories            • [   0% ] waiting    05m49.0s
+
+running (06m42.0s), 45/51 VUs, 341 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  68% ] 45/50 VUs  1m42.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m48.0s
+get_by_id                 • [   0% ] waiting    03m18.0s
+get_categories            • [   0% ] waiting    05m48.0s
+time="2026-03-12T13:24:57Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=silk&categoryName=Home%20Decor&size=20\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (06m43.0s), 47/51 VUs, 343 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  69% ] 47/50 VUs  1m43.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m47.0s
+get_by_id                 • [   0% ] waiting    03m17.0s
+get_categories            • [   0% ] waiting    05m47.0s
+
+running (06m44.0s), 48/51 VUs, 343 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  69% ] 48/50 VUs  1m44.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m46.0s
+get_by_id                 • [   0% ] waiting    03m16.0s
+get_categories            • [   0% ] waiting    05m46.0s
+time="2026-03-12T13:24:59Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=canvas&categoryName=Men's%20Clothing&size=20\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (06m45.0s), 49/51 VUs, 344 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  70% ] 49/50 VUs  1m45.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m45.0s
+get_by_id                 • [   0% ] waiting    03m15.0s
+get_categories            • [   0% ] waiting    05m45.0s
+time="2026-03-12T13:25:00Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=suede&categoryName=Jewelry&size=20\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (06m46.0s), 50/51 VUs, 345 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  71% ] 50/50 VUs  1m46.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m44.0s
+get_by_id                 • [   0% ] waiting    03m14.0s
+get_categories            • [   0% ] waiting    05m44.0s
+
+running (06m47.0s), 50/51 VUs, 347 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  71% ] 50/50 VUs  1m47.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m43.0s
+get_by_id                 • [   0% ] waiting    03m13.0s
+get_categories            • [   0% ] waiting    05m43.0s
+
+running (06m48.0s), 50/51 VUs, 348 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  72% ] 50/50 VUs  1m48.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m42.0s
+get_by_id                 • [   0% ] waiting    03m12.0s
+get_categories            • [   0% ] waiting    05m42.0s
+
+running (06m49.0s), 50/51 VUs, 349 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  73% ] 50/50 VUs  1m49.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m41.0s
+get_by_id                 • [   0% ] waiting    03m11.0s
+get_categories            • [   0% ] waiting    05m41.0s
+
+running (06m50.0s), 50/51 VUs, 351 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  73% ] 50/50 VUs  1m50.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m40.0s
+get_by_id                 • [   0% ] waiting    03m10.0s
+get_categories            • [   0% ] waiting    05m40.0s
+
+running (06m51.0s), 50/51 VUs, 352 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  74% ] 50/50 VUs  1m51.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m39.0s
+get_by_id                 • [   0% ] waiting    03m09.0s
+get_categories            • [   0% ] waiting    05m39.0s
+
+running (06m52.0s), 50/51 VUs, 354 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  75% ] 50/50 VUs  1m52.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m38.0s
+get_by_id                 • [   0% ] waiting    03m08.0s
+get_categories            • [   0% ] waiting    05m38.0s
+
+running (06m53.0s), 50/51 VUs, 355 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  75% ] 50/50 VUs  1m53.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m37.0s
+get_by_id                 • [   0% ] waiting    03m07.0s
+get_categories            • [   0% ] waiting    05m37.0s
+
+running (06m54.0s), 50/51 VUs, 358 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  76% ] 50/50 VUs  1m54.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m36.0s
+get_by_id                 • [   0% ] waiting    03m06.0s
+get_categories            • [   0% ] waiting    05m36.0s
+
+running (06m55.0s), 50/51 VUs, 359 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  77% ] 50/50 VUs  1m55.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m35.0s
+get_by_id                 • [   0% ] waiting    03m05.0s
+get_categories            • [   0% ] waiting    05m35.0s
+
+running (06m56.0s), 50/51 VUs, 360 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  77% ] 50/50 VUs  1m56.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m34.0s
+get_by_id                 • [   0% ] waiting    03m04.0s
+get_categories            • [   0% ] waiting    05m34.0s
+
+running (06m57.0s), 50/51 VUs, 362 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  78% ] 50/50 VUs  1m57.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m33.0s
+get_by_id                 • [   0% ] waiting    03m03.0s
+get_categories            • [   0% ] waiting    05m33.0s
+
+running (06m58.0s), 50/51 VUs, 363 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  79% ] 50/50 VUs  1m58.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m32.0s
+get_by_id                 • [   0% ] waiting    03m02.0s
+get_categories            • [   0% ] waiting    05m32.0s
+
+running (06m59.0s), 50/51 VUs, 364 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  79% ] 50/50 VUs  1m59.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m31.0s
+get_by_id                 • [   0% ] waiting    03m01.0s
+get_categories            • [   0% ] waiting    05m31.0s
+
+running (07m00.0s), 50/51 VUs, 366 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  80% ] 50/50 VUs  2m00.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m30.0s
+get_by_id                 • [   0% ] waiting    03m00.0s
+get_categories            • [   0% ] waiting    05m30.0s
+
+running (07m01.0s), 50/51 VUs, 367 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  81% ] 50/50 VUs  2m01.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m29.0s
+get_by_id                 • [   0% ] waiting    02m59.0s
+get_categories            • [   0% ] waiting    05m29.0s
+
+running (07m02.0s), 50/51 VUs, 368 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  81% ] 50/50 VUs  2m02.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m28.0s
+get_by_id                 • [   0% ] waiting    02m58.0s
+get_categories            • [   0% ] waiting    05m28.0s
+
+running (07m03.0s), 50/51 VUs, 370 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  82% ] 50/50 VUs  2m03.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m27.0s
+get_by_id                 • [   0% ] waiting    02m57.0s
+get_categories            • [   0% ] waiting    05m27.0s
+
+running (07m04.0s), 50/51 VUs, 373 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  83% ] 50/50 VUs  2m04.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m26.0s
+get_by_id                 • [   0% ] waiting    02m56.0s
+get_categories            • [   0% ] waiting    05m26.0s
+
+running (07m05.0s), 50/51 VUs, 374 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  83% ] 50/50 VUs  2m05.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m25.0s
+get_by_id                 • [   0% ] waiting    02m55.0s
+get_categories            • [   0% ] waiting    05m25.0s
+
+running (07m06.0s), 50/51 VUs, 375 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  84% ] 50/50 VUs  2m06.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m24.0s
+get_by_id                 • [   0% ] waiting    02m54.0s
+get_categories            • [   0% ] waiting    05m24.0s
+
+running (07m07.0s), 50/51 VUs, 377 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  85% ] 50/50 VUs  2m07.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m23.0s
+get_by_id                 • [   0% ] waiting    02m53.0s
+get_categories            • [   0% ] waiting    05m23.0s
+
+running (07m08.0s), 50/51 VUs, 378 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  85% ] 50/50 VUs  2m08.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m22.0s
+get_by_id                 • [   0% ] waiting    02m52.0s
+get_categories            • [   0% ] waiting    05m22.0s
+
+running (07m09.0s), 50/51 VUs, 379 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  86% ] 50/50 VUs  2m09.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m21.0s
+get_by_id                 • [   0% ] waiting    02m51.0s
+get_categories            • [   0% ] waiting    05m21.0s
+
+running (07m10.0s), 50/51 VUs, 381 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  87% ] 50/50 VUs  2m10.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m20.0s
+get_by_id                 • [   0% ] waiting    02m50.0s
+get_categories            • [   0% ] waiting    05m20.0s
+
+running (07m11.0s), 50/51 VUs, 383 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  87% ] 50/50 VUs  2m11.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m19.0s
+get_by_id                 • [   0% ] waiting    02m49.0s
+get_categories            • [   0% ] waiting    05m19.0s
+
+running (07m12.0s), 50/51 VUs, 385 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  88% ] 50/50 VUs  2m12.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m18.0s
+get_by_id                 • [   0% ] waiting    02m48.0s
+get_categories            • [   0% ] waiting    05m18.0s
+
+running (07m13.0s), 50/51 VUs, 385 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  89% ] 50/50 VUs  2m13.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m17.0s
+get_by_id                 • [   0% ] waiting    02m47.0s
+get_categories            • [   0% ] waiting    05m17.0s
+
+running (07m14.0s), 50/51 VUs, 387 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  89% ] 50/50 VUs  2m14.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m16.0s
+get_by_id                 • [   0% ] waiting    02m46.0s
+get_categories            • [   0% ] waiting    05m16.0s
+
+running (07m15.0s), 50/51 VUs, 388 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  90% ] 50/50 VUs  2m15.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m15.0s
+get_by_id                 • [   0% ] waiting    02m45.0s
+get_categories            • [   0% ] waiting    05m15.0s
+
+running (07m16.0s), 50/51 VUs, 389 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  91% ] 50/50 VUs  2m16.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m14.0s
+get_by_id                 • [   0% ] waiting    02m44.0s
+get_categories            • [   0% ] waiting    05m14.0s
+
+running (07m17.0s), 50/51 VUs, 391 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  91% ] 50/50 VUs  2m17.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m13.0s
+get_by_id                 • [   0% ] waiting    02m43.0s
+get_categories            • [   0% ] waiting    05m13.0s
+time="2026-03-12T13:25:33Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=bamboo&categoryName=Electronics%20Accessories&size=20\": request timeout"
+
+running (07m18.0s), 50/51 VUs, 391 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  92% ] 50/50 VUs  2m18.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m12.0s
+get_by_id                 • [   0% ] waiting    02m42.0s
+get_categories            • [   0% ] waiting    05m12.0s
+
+running (07m19.0s), 50/51 VUs, 393 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  93% ] 50/50 VUs  2m19.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m11.0s
+get_by_id                 • [   0% ] waiting    02m41.0s
+get_categories            • [   0% ] waiting    05m11.0s
+
+running (07m20.0s), 50/51 VUs, 394 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  93% ] 50/50 VUs  2m20.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m10.0s
+get_by_id                 • [   0% ] waiting    02m40.0s
+get_categories            • [   0% ] waiting    05m10.0s
+
+running (07m21.0s), 50/51 VUs, 395 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  94% ] 50/50 VUs  2m21.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m09.0s
+get_by_id                 • [   0% ] waiting    02m39.0s
+get_categories            • [   0% ] waiting    05m09.0s
+
+running (07m22.0s), 50/51 VUs, 397 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  95% ] 50/50 VUs  2m22.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m08.0s
+get_by_id                 • [   0% ] waiting    02m38.0s
+get_categories            • [   0% ] waiting    05m08.0s
+
+running (07m23.0s), 50/51 VUs, 399 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  95% ] 50/50 VUs  2m23.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m07.0s
+get_by_id                 • [   0% ] waiting    02m37.0s
+get_categories            • [   0% ] waiting    05m07.0s
+
+running (07m24.0s), 50/51 VUs, 400 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  96% ] 50/50 VUs  2m24.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m06.0s
+get_by_id                 • [   0% ] waiting    02m36.0s
+get_categories            • [   0% ] waiting    05m06.0s
+
+running (07m25.0s), 49/51 VUs, 401 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  97% ] 49/50 VUs  2m25.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m05.0s
+get_by_id                 • [   0% ] waiting    02m35.0s
+get_categories            • [   0% ] waiting    05m05.0s
+time="2026-03-12T13:25:40Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=ceramic&categoryName=Women's%20Clothing&size=20\": request timeout"
+
+running (07m26.0s), 48/51 VUs, 402 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  97% ] 48/50 VUs  2m26.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m04.0s
+get_by_id                 • [   0% ] waiting    02m34.0s
+get_categories            • [   0% ] waiting    05m04.0s
+
+running (07m27.0s), 46/51 VUs, 404 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  98% ] 46/50 VUs  2m27.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m03.0s
+get_by_id                 • [   0% ] waiting    02m33.0s
+get_categories            • [   0% ] waiting    05m03.0s
+
+running (07m28.0s), 46/51 VUs, 405 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  99% ] 46/50 VUs  2m28.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m02.0s
+get_by_id                 • [   0% ] waiting    02m32.0s
+get_categories            • [   0% ] waiting    05m02.0s
+
+running (07m29.0s), 44/51 VUs, 407 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [  99% ] 44/50 VUs  2m29.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m01.0s
+get_by_id                 • [   0% ] waiting    02m31.0s
+get_categories            • [   0% ] waiting    05m01.0s
+time="2026-03-12T13:25:44Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=wool&categoryName=Sports%20%26%20Outdoors&size=20\": request timeout"
+
+running (07m30.0s), 42/51 VUs, 409 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search          [ 100% ] 42/50 VUs  2m30.0s/2m30.0s
+autocomplete              • [   0% ] waiting    0m00.0s
+get_by_id                 • [   0% ] waiting    02m30.0s
+get_categories            • [   0% ] waiting    05m00.0s
+
+running (07m31.0s), 42/51 VUs, 410 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ↓ [ 100% ] 42/50 VUs  2m30s
+autocomplete                [   1% ] 01/50 VUs  0m01.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    02m29.0s
+get_categories            • [   0% ] waiting    04m59.0s
+
+running (07m32.0s), 41/51 VUs, 411 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ↓ [ 100% ] 42/50 VUs  2m30s
+autocomplete                [   1% ] 01/50 VUs  0m02.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    02m28.0s
+get_categories            • [   0% ] waiting    04m58.0s
+
+running (07m33.0s), 38/51 VUs, 414 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ↓ [ 100% ] 42/50 VUs  2m30s
+autocomplete                [   2% ] 01/50 VUs  0m03.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    02m27.0s
+get_categories            • [   0% ] waiting    04m57.0s
+
+running (07m34.0s), 36/51 VUs, 416 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ↓ [ 100% ] 42/50 VUs  2m30s
+autocomplete                [   3% ] 01/50 VUs  0m04.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    02m26.0s
+get_categories            • [   0% ] waiting    04m56.0s
+
+running (07m35.0s), 34/51 VUs, 418 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ↓ [ 100% ] 42/50 VUs  2m30s
+autocomplete                [   3% ] 01/50 VUs  0m05.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    02m25.0s
+get_categories            • [   0% ] waiting    04m55.0s
+time="2026-03-12T13:25:50Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=leather&categoryName=Electronics%20Accessories&size=20\": request timeout"
+
+running (07m36.0s), 32/51 VUs, 420 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ↓ [ 100% ] 42/50 VUs  2m30s
+autocomplete                [   4% ] 01/50 VUs  0m06.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    02m24.0s
+get_categories            • [   0% ] waiting    04m54.0s
+
+running (07m37.0s), 32/51 VUs, 420 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ↓ [ 100% ] 42/50 VUs  2m30s
+autocomplete                [   5% ] 01/50 VUs  0m07.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    02m23.0s
+get_categories            • [   0% ] waiting    04m53.0s
+
+running (07m38.0s), 29/51 VUs, 423 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ↓ [ 100% ] 42/50 VUs  2m30s
+autocomplete                [   5% ] 01/50 VUs  0m08.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    02m22.0s
+get_categories            • [   0% ] waiting    04m52.0s
+
+running (07m39.0s), 28/51 VUs, 424 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ↓ [ 100% ] 42/50 VUs  2m30s
+autocomplete                [   6% ] 01/50 VUs  0m09.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    02m21.0s
+get_categories            • [   0% ] waiting    04m51.0s
+
+running (07m40.0s), 27/51 VUs, 425 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ↓ [ 100% ] 42/50 VUs  2m30s
+autocomplete                [   7% ] 01/50 VUs  0m10.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    02m20.0s
+get_categories            • [   0% ] waiting    04m50.0s
+
+running (07m41.0s), 24/51 VUs, 428 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ↓ [ 100% ] 42/50 VUs  2m30s
+autocomplete                [   7% ] 01/50 VUs  0m11.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    02m19.0s
+get_categories            • [   0% ] waiting    04m49.0s
+
+running (07m42.0s), 23/51 VUs, 429 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ↓ [ 100% ] 42/50 VUs  2m30s
+autocomplete                [   8% ] 01/50 VUs  0m12.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    02m18.0s
+get_categories            • [   0% ] waiting    04m48.0s
+time="2026-03-12T13:25:57Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=marble&categoryName=Jewelry&size=20\": request timeout"
+
+running (07m43.0s), 22/51 VUs, 430 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ↓ [ 100% ] 42/50 VUs  2m30s
+autocomplete                [   9% ] 01/50 VUs  0m13.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    02m17.0s
+get_categories            • [   0% ] waiting    04m47.0s
+
+running (07m44.0s), 19/51 VUs, 433 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ↓ [ 100% ] 42/50 VUs  2m30s
+autocomplete                [   9% ] 01/50 VUs  0m14.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    02m16.0s
+get_categories            • [   0% ] waiting    04m46.0s
+
+running (07m45.0s), 19/51 VUs, 433 complete and 2 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ↓ [ 100% ] 42/50 VUs  2m30s
+autocomplete                [  10% ] 01/50 VUs  0m15.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    02m15.0s
+get_categories            • [   0% ] waiting    04m45.0s
+
+running (07m46.0s), 16/51 VUs, 433 complete and 5 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ↓ [ 100% ] 42/50 VUs  2m30s
+autocomplete                [  11% ] 01/50 VUs  0m16.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    02m14.0s
+get_categories            • [   0% ] waiting    04m44.0s
+
+running (07m47.0s), 16/51 VUs, 433 complete and 5 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ↓ [ 100% ] 42/50 VUs  2m30s
+autocomplete                [  11% ] 01/50 VUs  0m17.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    02m13.0s
+get_categories            • [   0% ] waiting    04m43.0s
+
+running (07m48.0s), 14/51 VUs, 435 complete and 5 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ↓ [ 100% ] 42/50 VUs  2m30s
+autocomplete                [  12% ] 01/50 VUs  0m18.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    02m12.0s
+get_categories            • [   0% ] waiting    04m42.0s
+
+running (07m49.0s), 13/51 VUs, 437 complete and 5 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ↓ [ 100% ] 42/50 VUs  2m30s
+autocomplete                [  13% ] 02/50 VUs  0m19.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    02m11.0s
+get_categories            • [   0% ] waiting    04m41.0s
+time="2026-03-12T13:26:05Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=copper&categoryName=Beauty%20%26%20Personal%20Care&size=20\": request timeout"
+
+running (07m50.0s), 12/51 VUs, 438 complete and 5 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ↓ [ 100% ] 42/50 VUs  2m30s
+autocomplete                [  13% ] 02/50 VUs  0m20.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    02m10.0s
+get_categories            • [   0% ] waiting    04m40.0s
+
+running (07m51.0s), 10/51 VUs, 440 complete and 5 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ↓ [ 100% ] 42/50 VUs  2m30s
+autocomplete                [  14% ] 02/50 VUs  0m21.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    02m09.0s
+get_categories            • [   0% ] waiting    04m39.0s
+
+running (07m52.0s), 10/51 VUs, 441 complete and 5 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ↓ [ 100% ] 42/50 VUs  2m30s
+autocomplete                [  15% ] 03/50 VUs  0m22.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    02m08.0s
+get_categories            • [   0% ] waiting    04m38.0s
+
+running (07m53.0s), 07/51 VUs, 443 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ↓ [ 100% ] 42/50 VUs  2m30s
+autocomplete                [  15% ] 03/50 VUs  0m23.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    02m07.0s
+get_categories            • [   0% ] waiting    04m37.0s
+time="2026-03-12T13:26:08Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?query=wool&categoryName=Men's%20Clothing&size=20\": request timeout"
+
+running (07m54.0s), 06/51 VUs, 444 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ↓ [ 100% ] 42/50 VUs  2m30s
+autocomplete                [  16% ] 03/50 VUs  0m24.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    02m06.0s
+get_categories            • [   0% ] waiting    04m36.0s
+
+running (07m55.0s), 04/51 VUs, 446 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ↓ [ 100% ] 42/50 VUs  2m30s
+autocomplete                [  17% ] 03/50 VUs  0m25.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    02m05.0s
+get_categories            • [   0% ] waiting    04m35.0s
+
+running (07m56.0s), 05/51 VUs, 446 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ↓ [ 100% ] 42/50 VUs  2m30s
+autocomplete                [  17% ] 04/50 VUs  0m26.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    02m04.0s
+get_categories            • [   0% ] waiting    04m34.0s
+
+running (07m57.0s), 05/51 VUs, 446 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ↓ [ 100% ] 42/50 VUs  2m30s
+autocomplete                [  18% ] 04/50 VUs  0m27.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    02m03.0s
+get_categories            • [   0% ] waiting    04m33.0s
+
+running (07m58.0s), 04/51 VUs, 447 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  19% ] 04/50 VUs  0m28.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    02m02.0s
+get_categories            • [   0% ] waiting    04m32.0s
+
+running (07m59.0s), 05/51 VUs, 447 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  19% ] 05/50 VUs  0m29.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    02m01.0s
+get_categories            • [   0% ] waiting    04m31.0s
+
+running (08m00.0s), 05/51 VUs, 447 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  20% ] 05/50 VUs  0m30.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    02m00.0s
+get_categories            • [   0% ] waiting    04m30.0s
+
+running (08m01.0s), 05/51 VUs, 448 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  21% ] 05/50 VUs  0m31.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m59.0s
+get_categories            • [   0% ] waiting    04m29.0s
+
+running (08m02.0s), 06/51 VUs, 448 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  21% ] 06/50 VUs  0m32.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m58.0s
+get_categories            • [   0% ] waiting    04m28.0s
+
+running (08m03.0s), 06/51 VUs, 448 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  22% ] 06/50 VUs  0m33.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m57.0s
+get_categories            • [   0% ] waiting    04m27.0s
+
+running (08m04.0s), 06/51 VUs, 448 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  23% ] 06/50 VUs  0m34.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m56.0s
+get_categories            • [   0% ] waiting    04m26.0s
+
+running (08m05.0s), 06/51 VUs, 448 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  23% ] 06/50 VUs  0m35.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m55.0s
+get_categories            • [   0% ] waiting    04m25.0s
+
+running (08m06.0s), 07/51 VUs, 448 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  24% ] 07/50 VUs  0m36.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m54.0s
+get_categories            • [   0% ] waiting    04m24.0s
+
+running (08m07.0s), 07/51 VUs, 448 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  25% ] 07/50 VUs  0m37.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m53.0s
+get_categories            • [   0% ] waiting    04m23.0s
+
+running (08m08.0s), 07/51 VUs, 448 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  25% ] 07/50 VUs  0m38.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m52.0s
+get_categories            • [   0% ] waiting    04m22.0s
+
+running (08m09.0s), 08/51 VUs, 448 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  26% ] 08/50 VUs  0m39.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m51.0s
+get_categories            • [   0% ] waiting    04m21.0s
+
+running (08m10.0s), 08/51 VUs, 448 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  27% ] 08/50 VUs  0m40.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m50.0s
+get_categories            • [   0% ] waiting    04m20.0s
+
+running (08m11.0s), 08/51 VUs, 448 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  27% ] 08/50 VUs  0m41.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m49.0s
+get_categories            • [   0% ] waiting    04m19.0s
+
+running (08m12.0s), 09/51 VUs, 448 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  28% ] 09/50 VUs  0m42.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m48.0s
+get_categories            • [   0% ] waiting    04m18.0s
+
+running (08m13.0s), 09/51 VUs, 448 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  29% ] 09/50 VUs  0m43.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m47.0s
+get_categories            • [   0% ] waiting    04m17.0s
+
+running (08m14.0s), 09/51 VUs, 448 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  29% ] 09/50 VUs  0m44.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m46.0s
+get_categories            • [   0% ] waiting    04m16.0s
+
+running (08m15.0s), 09/51 VUs, 448 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  30% ] 09/50 VUs  0m45.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m45.0s
+get_categories            • [   0% ] waiting    04m15.0s
+
+running (08m16.0s), 10/51 VUs, 448 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  31% ] 10/50 VUs  0m46.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m44.0s
+get_categories            • [   0% ] waiting    04m14.0s
+
+running (08m17.0s), 10/51 VUs, 448 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  31% ] 10/50 VUs  0m47.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m43.0s
+get_categories            • [   0% ] waiting    04m13.0s
+
+running (08m18.0s), 10/51 VUs, 448 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  32% ] 10/50 VUs  0m48.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m42.0s
+get_categories            • [   0% ] waiting    04m12.0s
+
+running (08m19.0s), 10/51 VUs, 448 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  33% ] 10/50 VUs  0m49.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m41.0s
+get_categories            • [   0% ] waiting    04m11.0s
+
+running (08m20.0s), 10/51 VUs, 448 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  33% ] 10/50 VUs  0m50.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m40.0s
+get_categories            • [   0% ] waiting    04m10.0s
+
+running (08m21.0s), 10/51 VUs, 448 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  34% ] 10/50 VUs  0m51.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m39.0s
+get_categories            • [   0% ] waiting    04m09.0s
+
+running (08m22.0s), 10/51 VUs, 448 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  35% ] 10/50 VUs  0m52.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m38.0s
+get_categories            • [   0% ] waiting    04m08.0s
+
+running (08m23.0s), 10/51 VUs, 448 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  35% ] 10/50 VUs  0m53.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m37.0s
+get_categories            • [   0% ] waiting    04m07.0s
+
+running (08m24.0s), 10/51 VUs, 448 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  36% ] 10/50 VUs  0m54.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m36.0s
+get_categories            • [   0% ] waiting    04m06.0s
+
+running (08m25.0s), 10/51 VUs, 448 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  37% ] 10/50 VUs  0m55.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m35.0s
+get_categories            • [   0% ] waiting    04m05.0s
+
+running (08m26.0s), 10/51 VUs, 448 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  37% ] 10/50 VUs  0m56.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m34.0s
+get_categories            • [   0% ] waiting    04m04.0s
+
+running (08m27.0s), 10/51 VUs, 448 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  38% ] 10/50 VUs  0m57.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m33.0s
+get_categories            • [   0% ] waiting    04m03.0s
+
+running (08m28.0s), 10/51 VUs, 448 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  39% ] 10/50 VUs  0m58.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m32.0s
+get_categories            • [   0% ] waiting    04m02.0s
+
+running (08m29.0s), 10/51 VUs, 448 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  39% ] 10/50 VUs  0m59.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m31.0s
+get_categories            • [   0% ] waiting    04m01.0s
+
+running (08m30.0s), 10/51 VUs, 448 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  40% ] 10/50 VUs  1m00.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m30.0s
+get_categories            • [   0% ] waiting    04m00.0s
+
+running (08m31.0s), 10/51 VUs, 448 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  41% ] 10/50 VUs  1m01.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m29.0s
+get_categories            • [   0% ] waiting    03m59.0s
+
+running (08m32.0s), 10/51 VUs, 448 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  41% ] 10/50 VUs  1m02.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m28.0s
+get_categories            • [   0% ] waiting    03m58.0s
+
+running (08m33.0s), 10/51 VUs, 448 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  42% ] 10/50 VUs  1m03.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m27.0s
+get_categories            • [   0% ] waiting    03m57.0s
+
+running (08m34.0s), 10/51 VUs, 448 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  43% ] 10/50 VUs  1m04.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m26.0s
+get_categories            • [   0% ] waiting    03m56.0s
+
+running (08m35.0s), 10/51 VUs, 448 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  43% ] 10/50 VUs  1m05.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m25.0s
+get_categories            • [   0% ] waiting    03m55.0s
+
+running (08m36.0s), 10/51 VUs, 448 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  44% ] 10/50 VUs  1m06.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m24.0s
+get_categories            • [   0% ] waiting    03m54.0s
+
+running (08m37.0s), 10/51 VUs, 448 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  45% ] 10/50 VUs  1m07.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m23.0s
+get_categories            • [   0% ] waiting    03m53.0s
+
+running (08m38.0s), 10/51 VUs, 448 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  45% ] 10/50 VUs  1m08.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m22.0s
+get_categories            • [   0% ] waiting    03m52.0s
+
+running (08m39.0s), 10/51 VUs, 448 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  46% ] 10/50 VUs  1m09.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m21.0s
+get_categories            • [   0% ] waiting    03m51.0s
+
+running (08m40.0s), 10/51 VUs, 448 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  47% ] 10/50 VUs  1m10.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m20.0s
+get_categories            • [   0% ] waiting    03m50.0s
+
+running (08m41.0s), 10/51 VUs, 448 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  47% ] 10/50 VUs  1m11.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m19.0s
+get_categories            • [   0% ] waiting    03m49.0s
+
+running (08m42.0s), 10/51 VUs, 448 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  48% ] 10/50 VUs  1m12.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m18.0s
+get_categories            • [   0% ] waiting    03m48.0s
+
+running (08m43.0s), 10/51 VUs, 449 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  49% ] 10/50 VUs  1m13.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m17.0s
+get_categories            • [   0% ] waiting    03m47.0s
+
+running (08m44.0s), 10/51 VUs, 449 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  49% ] 10/50 VUs  1m14.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m16.0s
+get_categories            • [   0% ] waiting    03m46.0s
+
+running (08m45.0s), 10/51 VUs, 449 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  50% ] 10/50 VUs  1m15.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m15.0s
+get_categories            • [   0% ] waiting    03m45.0s
+
+running (08m46.0s), 11/51 VUs, 449 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  51% ] 11/50 VUs  1m16.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m14.0s
+get_categories            • [   0% ] waiting    03m44.0s
+time="2026-03-12T13:27:01Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products/suggest?prefix=Nat&limit=10\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (08m47.0s), 12/51 VUs, 450 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  51% ] 12/50 VUs  1m17.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m13.0s
+get_categories            • [   0% ] waiting    03m43.0s
+
+running (08m48.0s), 13/51 VUs, 450 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  52% ] 13/50 VUs  1m18.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m12.0s
+get_categories            • [   0% ] waiting    03m42.0s
+time="2026-03-12T13:27:03Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products/suggest?prefix=Com&limit=10\": dial tcp 172.20.150.69:80: connect: connection refused"
+time="2026-03-12T13:27:03Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products/suggest?prefix=Ref&limit=10\": request timeout"
+
+running (08m49.0s), 15/51 VUs, 452 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  53% ] 15/50 VUs  1m19.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m11.0s
+get_categories            • [   0% ] waiting    03m41.0s
+time="2026-03-12T13:27:04Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products/suggest?prefix=Ess&limit=10\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (08m50.0s), 16/51 VUs, 453 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  53% ] 16/50 VUs  1m20.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m10.0s
+get_categories            • [   0% ] waiting    03m40.0s
+time="2026-03-12T13:27:05Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products/suggest?prefix=Bol&limit=10\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (08m51.0s), 17/51 VUs, 454 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  54% ] 17/50 VUs  1m21.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m09.0s
+get_categories            • [   0% ] waiting    03m39.0s
+time="2026-03-12T13:27:07Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products/suggest?prefix=Ess&limit=10\": request timeout"
+
+running (08m52.0s), 19/51 VUs, 455 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  55% ] 19/50 VUs  1m22.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m08.0s
+get_categories            • [   0% ] waiting    03m38.0s
+
+running (08m53.0s), 20/51 VUs, 455 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  55% ] 20/50 VUs  1m23.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m07.0s
+get_categories            • [   0% ] waiting    03m37.0s
+
+running (08m54.0s), 21/51 VUs, 455 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  56% ] 21/50 VUs  1m24.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m06.0s
+get_categories            • [   0% ] waiting    03m36.0s
+
+running (08m55.0s), 23/51 VUs, 455 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  57% ] 23/50 VUs  1m25.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m05.0s
+get_categories            • [   0% ] waiting    03m35.0s
+time="2026-03-12T13:27:10Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products/suggest?prefix=Pre&limit=10\": request timeout"
+
+running (08m56.0s), 24/51 VUs, 456 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  57% ] 24/50 VUs  1m26.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m04.0s
+get_categories            • [   0% ] waiting    03m34.0s
+time="2026-03-12T13:27:11Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products/suggest?prefix=Lux&limit=10\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (08m57.0s), 25/51 VUs, 457 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  58% ] 25/50 VUs  1m27.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m03.0s
+get_categories            • [   0% ] waiting    03m33.0s
+time="2026-03-12T13:27:13Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products/suggest?prefix=Org&limit=10\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (08m58.0s), 27/51 VUs, 457 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  59% ] 27/50 VUs  1m28.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m02.0s
+get_categories            • [   0% ] waiting    03m32.0s
+time="2026-03-12T13:27:13Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products/suggest?prefix=Art&limit=10\": dial tcp 172.20.150.69:80: connect: connection refused"
+time="2026-03-12T13:27:13Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products/suggest?prefix=Mod&limit=10\": request timeout"
+
+running (08m59.0s), 28/51 VUs, 460 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  59% ] 28/50 VUs  1m29.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m01.0s
+get_categories            • [   0% ] waiting    03m31.0s
+time="2026-03-12T13:27:14Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products/suggest?prefix=Ref&limit=10\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (09m00.0s), 29/51 VUs, 461 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  60% ] 29/50 VUs  1m30.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    01m00.0s
+get_categories            • [   0% ] waiting    03m30.0s
+time="2026-03-12T13:27:15Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products/suggest?prefix=Pre&limit=10\": request timeout"
+
+running (09m01.0s), 31/51 VUs, 462 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  61% ] 31/50 VUs  1m31.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m59.0s
+get_categories            • [   0% ] waiting    03m29.0s
+time="2026-03-12T13:27:17Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products/suggest?prefix=Ess&limit=10\": request timeout"
+
+running (09m02.0s), 32/51 VUs, 463 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  61% ] 32/50 VUs  1m32.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m58.0s
+get_categories            • [   0% ] waiting    03m28.0s
+time="2026-03-12T13:27:17Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products/suggest?prefix=Nat&limit=10\": dial tcp 172.20.150.69:80: connect: connection refused"
+time="2026-03-12T13:27:17Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products/suggest?prefix=Lux&limit=10\": dial tcp 172.20.150.69:80: connect: connection refused"
+time="2026-03-12T13:27:17Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products/suggest?prefix=Sma&limit=10\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (09m03.0s), 33/51 VUs, 466 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  62% ] 33/50 VUs  1m33.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m57.0s
+get_categories            • [   0% ] waiting    03m27.0s
+time="2026-03-12T13:27:19Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products/suggest?prefix=Art&limit=10\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (09m04.0s), 35/51 VUs, 466 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  63% ] 35/50 VUs  1m34.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m56.0s
+get_categories            • [   0% ] waiting    03m26.0s
+
+running (09m05.0s), 36/51 VUs, 467 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  63% ] 36/50 VUs  1m35.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m55.0s
+get_categories            • [   0% ] waiting    03m25.0s
+time="2026-03-12T13:27:20Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products/suggest?prefix=Ult&limit=10\": request timeout"
+
+running (09m06.0s), 37/51 VUs, 468 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  64% ] 37/50 VUs  1m36.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m54.0s
+get_categories            • [   0% ] waiting    03m24.0s
+time="2026-03-12T13:27:21Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products/suggest?prefix=Ele&limit=10\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (09m07.0s), 39/51 VUs, 469 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  65% ] 39/50 VUs  1m37.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m53.0s
+get_categories            • [   0% ] waiting    03m23.0s
+
+running (09m08.0s), 40/51 VUs, 469 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  65% ] 40/50 VUs  1m38.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m52.0s
+get_categories            • [   0% ] waiting    03m22.0s
+time="2026-03-12T13:27:23Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products/suggest?prefix=Sma&limit=10\": request timeout"
+time="2026-03-12T13:27:24Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products/suggest?prefix=Org&limit=10\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (09m09.0s), 41/51 VUs, 471 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  66% ] 41/50 VUs  1m39.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m51.0s
+get_categories            • [   0% ] waiting    03m21.0s
+time="2026-03-12T13:27:25Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products/suggest?prefix=Mod&limit=10\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (09m10.0s), 43/51 VUs, 471 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  67% ] 43/50 VUs  1m40.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m50.0s
+get_categories            • [   0% ] waiting    03m20.0s
+time="2026-03-12T13:27:25Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products/suggest?prefix=Ult&limit=10\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (09m11.0s), 44/51 VUs, 473 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  67% ] 44/50 VUs  1m41.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m49.0s
+get_categories            • [   0% ] waiting    03m19.0s
+
+running (09m12.0s), 45/51 VUs, 473 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  68% ] 45/50 VUs  1m42.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m48.0s
+get_categories            • [   0% ] waiting    03m18.0s
+
+running (09m13.0s), 47/51 VUs, 474 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  69% ] 47/50 VUs  1m43.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m47.0s
+get_categories            • [   0% ] waiting    03m17.0s
+
+running (09m14.0s), 48/51 VUs, 474 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  69% ] 48/50 VUs  1m44.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m46.0s
+get_categories            • [   0% ] waiting    03m16.0s
+
+running (09m15.0s), 49/51 VUs, 474 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  70% ] 49/50 VUs  1m45.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m45.0s
+get_categories            • [   0% ] waiting    03m15.0s
+time="2026-03-12T13:27:30Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products/suggest?prefix=Del&limit=10\": request timeout"
+time="2026-03-12T13:27:30Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products/suggest?prefix=Roy&limit=10\": dial tcp 172.20.150.69:80: connect: connection refused"
+time="2026-03-12T13:27:30Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products/suggest?prefix=Pre&limit=10\": dial tcp 172.20.150.69:80: connect: connection refused"
+time="2026-03-12T13:27:30Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products/suggest?prefix=Del&limit=10\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (09m16.0s), 50/51 VUs, 478 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  71% ] 50/50 VUs  1m46.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m44.0s
+get_categories            • [   0% ] waiting    03m14.0s
+
+running (09m17.0s), 50/51 VUs, 479 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  71% ] 50/50 VUs  1m47.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m43.0s
+get_categories            • [   0% ] waiting    03m13.0s
+
+running (09m18.0s), 50/51 VUs, 481 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  72% ] 50/50 VUs  1m48.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m42.0s
+get_categories            • [   0% ] waiting    03m12.0s
+
+running (09m19.0s), 50/51 VUs, 483 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  73% ] 50/50 VUs  1m49.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m41.0s
+get_categories            • [   0% ] waiting    03m11.0s
+
+running (09m20.0s), 50/51 VUs, 484 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  73% ] 50/50 VUs  1m50.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m40.0s
+get_categories            • [   0% ] waiting    03m10.0s
+
+running (09m21.0s), 50/51 VUs, 486 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  74% ] 50/50 VUs  1m51.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m39.0s
+get_categories            • [   0% ] waiting    03m09.0s
+
+running (09m22.0s), 50/51 VUs, 487 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  75% ] 50/50 VUs  1m52.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m38.0s
+get_categories            • [   0% ] waiting    03m08.0s
+
+running (09m23.0s), 50/51 VUs, 490 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  75% ] 50/50 VUs  1m53.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m37.0s
+get_categories            • [   0% ] waiting    03m07.0s
+
+running (09m24.0s), 50/51 VUs, 491 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  76% ] 50/50 VUs  1m54.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m36.0s
+get_categories            • [   0% ] waiting    03m06.0s
+
+running (09m25.0s), 50/51 VUs, 492 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  77% ] 50/50 VUs  1m55.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m35.0s
+get_categories            • [   0% ] waiting    03m05.0s
+
+running (09m26.0s), 50/51 VUs, 495 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  77% ] 50/50 VUs  1m56.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m34.0s
+get_categories            • [   0% ] waiting    03m04.0s
+
+running (09m27.0s), 50/51 VUs, 496 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  78% ] 50/50 VUs  1m57.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m33.0s
+get_categories            • [   0% ] waiting    03m03.0s
+
+running (09m28.0s), 50/51 VUs, 497 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  79% ] 50/50 VUs  1m58.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m32.0s
+get_categories            • [   0% ] waiting    03m02.0s
+
+running (09m29.0s), 50/51 VUs, 500 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  79% ] 50/50 VUs  1m59.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m31.0s
+get_categories            • [   0% ] waiting    03m01.0s
+
+running (09m30.0s), 50/51 VUs, 500 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  80% ] 50/50 VUs  2m00.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m30.0s
+get_categories            • [   0% ] waiting    03m00.0s
+
+running (09m31.0s), 50/51 VUs, 503 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  81% ] 50/50 VUs  2m01.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m29.0s
+get_categories            • [   0% ] waiting    02m59.0s
+
+running (09m32.0s), 50/51 VUs, 505 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  81% ] 50/50 VUs  2m02.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m28.0s
+get_categories            • [   0% ] waiting    02m58.0s
+
+running (09m33.0s), 50/51 VUs, 506 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  82% ] 50/50 VUs  2m03.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m27.0s
+get_categories            • [   0% ] waiting    02m57.0s
+
+running (09m34.0s), 50/51 VUs, 508 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  83% ] 50/50 VUs  2m04.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m26.0s
+get_categories            • [   0% ] waiting    02m56.0s
+
+running (09m35.0s), 50/51 VUs, 510 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  83% ] 50/50 VUs  2m05.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m25.0s
+get_categories            • [   0% ] waiting    02m55.0s
+
+running (09m36.0s), 50/51 VUs, 512 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  84% ] 50/50 VUs  2m06.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m24.0s
+get_categories            • [   0% ] waiting    02m54.0s
+
+running (09m37.0s), 50/51 VUs, 513 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  85% ] 50/50 VUs  2m07.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m23.0s
+get_categories            • [   0% ] waiting    02m53.0s
+
+running (09m38.0s), 50/51 VUs, 515 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  85% ] 50/50 VUs  2m08.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m22.0s
+get_categories            • [   0% ] waiting    02m52.0s
+
+running (09m39.0s), 50/51 VUs, 516 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  86% ] 50/50 VUs  2m09.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m21.0s
+get_categories            • [   0% ] waiting    02m51.0s
+
+running (09m40.0s), 50/51 VUs, 518 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  87% ] 50/50 VUs  2m10.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m20.0s
+get_categories            • [   0% ] waiting    02m50.0s
+
+running (09m41.0s), 50/51 VUs, 520 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  87% ] 50/50 VUs  2m11.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m19.0s
+get_categories            • [   0% ] waiting    02m49.0s
+
+running (09m42.0s), 50/51 VUs, 521 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  88% ] 50/50 VUs  2m12.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m18.0s
+get_categories            • [   0% ] waiting    02m48.0s
+
+running (09m43.0s), 50/51 VUs, 523 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  89% ] 50/50 VUs  2m13.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m17.0s
+get_categories            • [   0% ] waiting    02m47.0s
+
+running (09m44.0s), 50/51 VUs, 525 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  89% ] 50/50 VUs  2m14.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m16.0s
+get_categories            • [   0% ] waiting    02m46.0s
+
+running (09m45.0s), 50/51 VUs, 526 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  90% ] 50/50 VUs  2m15.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m15.0s
+get_categories            • [   0% ] waiting    02m45.0s
+
+running (09m46.0s), 50/51 VUs, 527 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  91% ] 50/50 VUs  2m16.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m14.0s
+get_categories            • [   0% ] waiting    02m44.0s
+
+running (09m47.0s), 49/51 VUs, 529 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  91% ] 49/50 VUs  2m17.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m13.0s
+get_categories            • [   0% ] waiting    02m43.0s
+
+running (09m48.0s), 49/51 VUs, 531 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  92% ] 49/50 VUs  2m18.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m12.0s
+get_categories            • [   0% ] waiting    02m42.0s
+
+running (09m49.0s), 49/51 VUs, 532 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  93% ] 49/50 VUs  2m19.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m11.0s
+get_categories            • [   0% ] waiting    02m41.0s
+
+running (09m50.0s), 49/51 VUs, 534 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  93% ] 49/50 VUs  2m20.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m10.0s
+get_categories            • [   0% ] waiting    02m40.0s
+
+running (09m51.0s), 49/51 VUs, 535 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  94% ] 49/50 VUs  2m21.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m09.0s
+get_categories            • [   0% ] waiting    02m39.0s
+
+running (09m52.0s), 49/51 VUs, 537 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  95% ] 49/50 VUs  2m22.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m08.0s
+get_categories            • [   0% ] waiting    02m38.0s
+
+running (09m53.0s), 49/51 VUs, 539 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  95% ] 49/50 VUs  2m23.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m07.0s
+get_categories            • [   0% ] waiting    02m37.0s
+
+running (09m54.0s), 49/51 VUs, 541 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  96% ] 49/50 VUs  2m24.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m06.0s
+get_categories            • [   0% ] waiting    02m36.0s
+
+running (09m55.0s), 48/51 VUs, 542 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  97% ] 48/50 VUs  2m25.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m05.0s
+get_categories            • [   0% ] waiting    02m35.0s
+
+running (09m56.0s), 47/51 VUs, 544 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  97% ] 47/50 VUs  2m26.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m04.0s
+get_categories            • [   0% ] waiting    02m34.0s
+
+running (09m57.0s), 46/51 VUs, 545 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  98% ] 46/50 VUs  2m27.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m03.0s
+get_categories            • [   0% ] waiting    02m33.0s
+
+running (09m58.0s), 44/51 VUs, 547 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  99% ] 44/50 VUs  2m28.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m02.0s
+get_categories            • [   0% ] waiting    02m32.0s
+
+running (09m59.0s), 43/51 VUs, 548 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [  99% ] 43/50 VUs  2m29.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m01.0s
+get_categories            • [   0% ] waiting    02m31.0s
+
+running (10m00.0s), 41/51 VUs, 550 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete                [ 100% ] 41/50 VUs  2m30.0s/2m30.0s
+get_by_id                 • [   0% ] waiting    00m00.0s
+get_categories            • [   0% ] waiting    02m30.0s
+
+running (10m01.0s), 40/51 VUs, 552 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ↓ [ 100% ] 41/50 VUs  2m30s
+get_by_id                   [   1% ] 01/50 VUs  0m01.0s/2m30.0s
+get_categories            • [   0% ] waiting    02m29.0s
+
+running (10m02.0s), 38/51 VUs, 554 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ↓ [ 100% ] 41/50 VUs  2m30s
+get_by_id                   [   1% ] 01/50 VUs  0m02.0s/2m30.0s
+get_categories            • [   0% ] waiting    02m28.0s
+
+running (10m03.0s), 36/51 VUs, 556 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ↓ [ 100% ] 41/50 VUs  2m30s
+get_by_id                   [   2% ] 01/50 VUs  0m03.0s/2m30.0s
+get_categories            • [   0% ] waiting    02m27.0s
+
+running (10m04.0s), 34/51 VUs, 558 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ↓ [ 100% ] 41/50 VUs  2m30s
+get_by_id                   [   3% ] 01/50 VUs  0m04.0s/2m30.0s
+get_categories            • [   0% ] waiting    02m26.0s
+
+running (10m05.0s), 33/51 VUs, 559 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ↓ [ 100% ] 41/50 VUs  2m30s
+get_by_id                   [   3% ] 01/50 VUs  0m05.0s/2m30.0s
+get_categories            • [   0% ] waiting    02m25.0s
+
+running (10m06.0s), 30/51 VUs, 562 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ↓ [ 100% ] 41/50 VUs  2m30s
+get_by_id                   [   4% ] 01/50 VUs  0m06.0s/2m30.0s
+get_categories            • [   0% ] waiting    02m24.0s
+
+running (10m07.0s), 29/51 VUs, 563 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ↓ [ 100% ] 41/50 VUs  2m30s
+get_by_id                   [   5% ] 01/50 VUs  0m07.0s/2m30.0s
+get_categories            • [   0% ] waiting    02m23.0s
+
+running (10m08.0s), 28/51 VUs, 564 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ↓ [ 100% ] 41/50 VUs  2m30s
+get_by_id                   [   5% ] 01/50 VUs  0m08.0s/2m30.0s
+get_categories            • [   0% ] waiting    02m22.0s
+
+running (10m09.0s), 26/51 VUs, 566 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ↓ [ 100% ] 41/50 VUs  2m30s
+get_by_id                   [   6% ] 01/50 VUs  0m09.0s/2m30.0s
+get_categories            • [   0% ] waiting    02m21.0s
+
+running (10m10.0s), 24/51 VUs, 568 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ↓ [ 100% ] 41/50 VUs  2m30s
+get_by_id                   [   7% ] 01/50 VUs  0m10.0s/2m30.0s
+get_categories            • [   0% ] waiting    02m20.0s
+
+running (10m11.0s), 24/51 VUs, 568 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ↓ [ 100% ] 41/50 VUs  2m30s
+get_by_id                   [   7% ] 01/50 VUs  0m11.0s/2m30.0s
+get_categories            • [   0% ] waiting    02m19.0s
+
+running (10m12.0s), 21/51 VUs, 571 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ↓ [ 100% ] 41/50 VUs  2m30s
+get_by_id                   [   8% ] 01/50 VUs  0m12.0s/2m30.0s
+get_categories            • [   0% ] waiting    02m18.0s
+
+running (10m13.0s), 19/51 VUs, 573 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ↓ [ 100% ] 41/50 VUs  2m30s
+get_by_id                   [   9% ] 01/50 VUs  0m13.0s/2m30.0s
+get_categories            • [   0% ] waiting    02m17.0s
+
+running (10m14.0s), 18/51 VUs, 574 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ↓ [ 100% ] 41/50 VUs  2m30s
+get_by_id                   [   9% ] 01/50 VUs  0m14.0s/2m30.0s
+get_categories            • [   0% ] waiting    02m16.0s
+
+running (10m15.0s), 16/51 VUs, 576 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ↓ [ 100% ] 41/50 VUs  2m30s
+get_by_id                   [  10% ] 01/50 VUs  0m15.0s/2m30.0s
+get_categories            • [   0% ] waiting    02m15.0s
+
+running (10m16.0s), 15/51 VUs, 577 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ↓ [ 100% ] 41/50 VUs  2m30s
+get_by_id                   [  11% ] 01/50 VUs  0m16.0s/2m30.0s
+get_categories            • [   0% ] waiting    02m14.0s
+
+running (10m17.0s), 14/51 VUs, 578 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ↓ [ 100% ] 41/50 VUs  2m30s
+get_by_id                   [  11% ] 01/50 VUs  0m17.0s/2m30.0s
+get_categories            • [   0% ] waiting    02m13.0s
+
+running (10m18.0s), 13/51 VUs, 579 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ↓ [ 100% ] 41/50 VUs  2m30s
+get_by_id                   [  12% ] 01/50 VUs  0m18.0s/2m30.0s
+get_categories            • [   0% ] waiting    02m12.0s
+
+running (10m19.0s), 13/51 VUs, 580 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ↓ [ 100% ] 41/50 VUs  2m30s
+get_by_id                   [  13% ] 02/50 VUs  0m19.0s/2m30.0s
+get_categories            • [   0% ] waiting    02m11.0s
+
+running (10m20.0s), 10/51 VUs, 583 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ↓ [ 100% ] 41/50 VUs  2m30s
+get_by_id                   [  13% ] 02/50 VUs  0m20.0s/2m30.0s
+get_categories            • [   0% ] waiting    02m10.0s
+
+running (10m21.0s), 09/51 VUs, 584 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ↓ [ 100% ] 41/50 VUs  2m30s
+get_by_id                   [  14% ] 02/50 VUs  0m21.0s/2m30.0s
+get_categories            • [   0% ] waiting    02m09.0s
+
+running (10m22.0s), 08/51 VUs, 586 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ↓ [ 100% ] 41/50 VUs  2m30s
+get_by_id                   [  15% ] 03/50 VUs  0m22.0s/2m30.0s
+get_categories            • [   0% ] waiting    02m08.0s
+
+running (10m23.0s), 06/51 VUs, 588 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ↓ [ 100% ] 41/50 VUs  2m30s
+get_by_id                   [  15% ] 03/50 VUs  0m23.0s/2m30.0s
+get_categories            • [   0% ] waiting    02m07.0s
+
+running (10m24.0s), 05/51 VUs, 589 complete and 6 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ↓ [ 100% ] 41/50 VUs  2m30s
+get_by_id                   [  16% ] 03/50 VUs  0m24.0s/2m30.0s
+get_categories            • [   0% ] waiting    02m06.0s
+
+running (10m25.0s), 04/51 VUs, 589 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ↓ [ 100% ] 41/50 VUs  2m30s
+get_by_id                   [  17% ] 03/50 VUs  0m25.0s/2m30.0s
+get_categories            • [   0% ] waiting    02m05.0s
+
+running (10m26.0s), 05/51 VUs, 589 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ↓ [ 100% ] 41/50 VUs  2m30s
+get_by_id                   [  17% ] 04/50 VUs  0m26.0s/2m30.0s
+get_categories            • [   0% ] waiting    02m04.0s
+
+running (10m27.0s), 04/51 VUs, 590 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  18% ] 04/50 VUs  0m27.0s/2m30.0s
+get_categories            • [   0% ] waiting    02m03.0s
+
+running (10m28.0s), 04/51 VUs, 590 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  19% ] 04/50 VUs  0m28.0s/2m30.0s
+get_categories            • [   0% ] waiting    02m02.0s
+
+running (10m29.0s), 05/51 VUs, 590 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  19% ] 05/50 VUs  0m29.0s/2m30.0s
+get_categories            • [   0% ] waiting    02m01.0s
+
+running (10m30.0s), 05/51 VUs, 590 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  20% ] 05/50 VUs  0m30.0s/2m30.0s
+get_categories            • [   0% ] waiting    02m00.0s
+
+running (10m31.0s), 05/51 VUs, 590 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  21% ] 05/50 VUs  0m31.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m59.0s
+
+running (10m32.0s), 06/51 VUs, 591 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  21% ] 06/50 VUs  0m32.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m58.0s
+
+running (10m33.0s), 06/51 VUs, 591 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  22% ] 06/50 VUs  0m33.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m57.0s
+
+running (10m34.0s), 06/51 VUs, 591 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  23% ] 06/50 VUs  0m34.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m56.0s
+
+running (10m35.0s), 06/51 VUs, 591 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  23% ] 06/50 VUs  0m35.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m55.0s
+
+running (10m36.0s), 07/51 VUs, 591 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  24% ] 07/50 VUs  0m36.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m54.0s
+
+running (10m37.0s), 07/51 VUs, 591 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  25% ] 07/50 VUs  0m37.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m53.0s
+
+running (10m38.0s), 07/51 VUs, 591 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  25% ] 07/50 VUs  0m38.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m52.0s
+
+running (10m39.0s), 08/51 VUs, 591 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  26% ] 08/50 VUs  0m39.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m51.0s
+
+running (10m40.0s), 08/51 VUs, 591 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  27% ] 08/50 VUs  0m40.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m50.0s
+
+running (10m41.0s), 08/51 VUs, 591 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  27% ] 08/50 VUs  0m41.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m49.0s
+
+running (10m42.0s), 09/51 VUs, 591 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  28% ] 09/50 VUs  0m42.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m48.0s
+
+running (10m43.0s), 09/51 VUs, 591 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  29% ] 09/50 VUs  0m43.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m47.0s
+
+running (10m44.0s), 09/51 VUs, 591 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  29% ] 09/50 VUs  0m44.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m46.0s
+
+running (10m45.0s), 09/51 VUs, 591 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  30% ] 09/50 VUs  0m45.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m45.0s
+
+running (10m46.0s), 10/51 VUs, 591 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  31% ] 10/50 VUs  0m46.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m44.0s
+
+running (10m47.0s), 10/51 VUs, 591 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  31% ] 10/50 VUs  0m47.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m43.0s
+
+running (10m48.0s), 10/51 VUs, 591 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  32% ] 10/50 VUs  0m48.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m42.0s
+
+running (10m49.0s), 10/51 VUs, 591 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  33% ] 10/50 VUs  0m49.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m41.0s
+
+running (10m50.0s), 10/51 VUs, 592 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  33% ] 10/50 VUs  0m50.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m40.0s
+
+running (10m51.0s), 10/51 VUs, 592 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  34% ] 10/50 VUs  0m51.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m39.0s
+
+running (10m52.0s), 10/51 VUs, 592 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  35% ] 10/50 VUs  0m52.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m38.0s
+
+running (10m53.0s), 10/51 VUs, 593 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  35% ] 10/50 VUs  0m53.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m37.0s
+
+running (10m54.0s), 10/51 VUs, 593 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  36% ] 10/50 VUs  0m54.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m36.0s
+
+running (10m55.0s), 10/51 VUs, 593 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  37% ] 10/50 VUs  0m55.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m35.0s
+
+running (10m56.0s), 10/51 VUs, 593 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  37% ] 10/50 VUs  0m56.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m34.0s
+
+running (10m57.0s), 10/51 VUs, 593 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  38% ] 10/50 VUs  0m57.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m33.0s
+
+running (10m58.0s), 10/51 VUs, 593 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  39% ] 10/50 VUs  0m58.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m32.0s
+
+running (10m59.0s), 10/51 VUs, 593 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  39% ] 10/50 VUs  0m59.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m31.0s
+
+running (11m00.0s), 10/51 VUs, 594 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  40% ] 10/50 VUs  1m00.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m30.0s
+
+running (11m01.0s), 10/51 VUs, 594 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  41% ] 10/50 VUs  1m01.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m29.0s
+
+running (11m02.0s), 10/51 VUs, 594 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  41% ] 10/50 VUs  1m02.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m28.0s
+
+running (11m03.0s), 10/51 VUs, 596 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  42% ] 10/50 VUs  1m03.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m27.0s
+
+running (11m04.0s), 10/51 VUs, 596 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  43% ] 10/50 VUs  1m04.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m26.0s
+
+running (11m05.0s), 10/51 VUs, 596 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  43% ] 10/50 VUs  1m05.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m25.0s
+
+running (11m06.0s), 10/51 VUs, 596 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  44% ] 10/50 VUs  1m06.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m24.0s
+
+running (11m07.0s), 10/51 VUs, 597 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  45% ] 10/50 VUs  1m07.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m23.0s
+
+running (11m08.0s), 10/51 VUs, 597 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  45% ] 10/50 VUs  1m08.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m22.0s
+
+running (11m09.0s), 10/51 VUs, 597 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  46% ] 10/50 VUs  1m09.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m21.0s
+
+running (11m10.0s), 10/51 VUs, 598 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  47% ] 10/50 VUs  1m10.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m20.0s
+
+running (11m11.0s), 10/51 VUs, 598 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  47% ] 10/50 VUs  1m11.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m19.0s
+
+running (11m12.0s), 10/51 VUs, 598 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  48% ] 10/50 VUs  1m12.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m18.0s
+
+running (11m13.0s), 10/51 VUs, 599 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  49% ] 10/50 VUs  1m13.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m17.0s
+
+running (11m14.0s), 10/51 VUs, 599 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  49% ] 10/50 VUs  1m14.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m16.0s
+
+running (11m15.0s), 10/51 VUs, 599 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  50% ] 10/50 VUs  1m15.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m15.0s
+
+running (11m16.0s), 11/51 VUs, 599 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  51% ] 11/50 VUs  1m16.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m14.0s
+
+running (11m17.0s), 12/51 VUs, 600 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  51% ] 12/50 VUs  1m17.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m13.0s
+
+running (11m18.0s), 13/51 VUs, 600 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  52% ] 13/50 VUs  1m18.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m12.0s
+
+running (11m19.0s), 15/51 VUs, 600 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  53% ] 15/50 VUs  1m19.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m11.0s
+time="2026-03-12T13:29:34Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?size=1\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (11m20.0s), 16/51 VUs, 600 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  53% ] 16/50 VUs  1m20.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m10.0s
+
+running (11m21.0s), 17/51 VUs, 602 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  54% ] 17/50 VUs  1m21.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m09.0s
+time="2026-03-12T13:29:37Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?size=1\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (11m22.0s), 19/51 VUs, 602 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  55% ] 19/50 VUs  1m22.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m08.0s
+time="2026-03-12T13:29:37Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?size=1\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (11m23.0s), 20/51 VUs, 603 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  55% ] 20/50 VUs  1m23.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m07.0s
+time="2026-03-12T13:29:38Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?size=1\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (11m24.0s), 21/51 VUs, 605 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  56% ] 21/50 VUs  1m24.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m06.0s
+
+running (11m25.0s), 23/51 VUs, 606 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  57% ] 23/50 VUs  1m25.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m05.0s
+time="2026-03-12T13:29:40Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?size=1\": request timeout"
+
+running (11m26.0s), 24/51 VUs, 606 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  57% ] 24/50 VUs  1m26.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m04.0s
+time="2026-03-12T13:29:41Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?size=1\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (11m27.0s), 25/51 VUs, 607 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  58% ] 25/50 VUs  1m27.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m03.0s
+
+running (11m28.0s), 27/51 VUs, 608 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  59% ] 27/50 VUs  1m28.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m02.0s
+time="2026-03-12T13:29:43Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?size=1\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (11m29.0s), 28/51 VUs, 608 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  59% ] 28/50 VUs  1m29.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m01.0s
+time="2026-03-12T13:29:44Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?size=1\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (11m30.0s), 29/51 VUs, 609 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  60% ] 29/50 VUs  1m30.0s/2m30.0s
+get_categories            • [   0% ] waiting    01m00.0s
+time="2026-03-12T13:29:45Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?size=1\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (11m31.0s), 31/51 VUs, 610 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  61% ] 31/50 VUs  1m31.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m59.0s
+
+running (11m32.0s), 32/51 VUs, 611 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  61% ] 32/50 VUs  1m32.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m58.0s
+
+running (11m33.0s), 33/51 VUs, 611 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  62% ] 33/50 VUs  1m33.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m57.0s
+time="2026-03-12T13:29:48Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?size=1\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (11m34.0s), 35/51 VUs, 612 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  63% ] 35/50 VUs  1m34.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m56.0s
+time="2026-03-12T13:29:49Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?size=1\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (11m35.0s), 36/51 VUs, 613 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  63% ] 36/50 VUs  1m35.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m55.0s
+time="2026-03-12T13:29:50Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?size=1\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (11m36.0s), 37/51 VUs, 614 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  64% ] 37/50 VUs  1m36.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m54.0s
+
+running (11m37.0s), 39/51 VUs, 615 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  65% ] 39/50 VUs  1m37.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m53.0s
+time="2026-03-12T13:29:52Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?size=1\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (11m38.0s), 40/51 VUs, 615 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  65% ] 40/50 VUs  1m38.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m52.0s
+
+running (11m39.0s), 41/51 VUs, 616 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  66% ] 41/50 VUs  1m39.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m51.0s
+time="2026-03-12T13:29:55Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?size=1\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (11m40.0s), 43/51 VUs, 616 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  67% ] 43/50 VUs  1m40.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m50.0s
+time="2026-03-12T13:29:56Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?size=1\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (11m41.0s), 44/51 VUs, 617 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  67% ] 44/50 VUs  1m41.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m49.0s
+time="2026-03-12T13:29:56Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?size=1\": dial tcp 172.20.150.69:80: connect: connection refused"
+time="2026-03-12T13:29:57Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?size=1\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (11m42.0s), 45/51 VUs, 618 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  68% ] 45/50 VUs  1m42.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m48.0s
+time="2026-03-12T13:29:58Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?size=1\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (11m43.0s), 47/51 VUs, 620 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  69% ] 47/50 VUs  1m43.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m47.0s
+time="2026-03-12T13:29:59Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?size=1\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (11m44.0s), 48/51 VUs, 622 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  69% ] 48/50 VUs  1m44.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m46.0s
+time="2026-03-12T13:30:00Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?size=1\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (11m45.0s), 49/51 VUs, 623 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  70% ] 49/50 VUs  1m45.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m45.0s
+time="2026-03-12T13:30:00Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?size=1\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (11m46.0s), 50/51 VUs, 624 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  71% ] 50/50 VUs  1m46.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m44.0s
+
+running (11m47.0s), 50/51 VUs, 626 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  71% ] 50/50 VUs  1m47.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m43.0s
+
+running (11m48.0s), 50/51 VUs, 628 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  72% ] 50/50 VUs  1m48.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m42.0s
+
+running (11m49.0s), 50/51 VUs, 629 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  73% ] 50/50 VUs  1m49.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m41.0s
+
+running (11m50.0s), 50/51 VUs, 630 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  73% ] 50/50 VUs  1m50.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m40.0s
+
+running (11m51.0s), 50/51 VUs, 630 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  74% ] 50/50 VUs  1m51.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m39.0s
+
+running (11m52.0s), 50/51 VUs, 633 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  75% ] 50/50 VUs  1m52.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m38.0s
+
+running (11m53.0s), 50/51 VUs, 633 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  75% ] 50/50 VUs  1m53.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m37.0s
+
+running (11m54.0s), 50/51 VUs, 633 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  76% ] 50/50 VUs  1m54.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m36.0s
+
+running (11m55.0s), 50/51 VUs, 635 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  77% ] 50/50 VUs  1m55.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m35.0s
+
+running (11m56.0s), 50/51 VUs, 638 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  77% ] 50/50 VUs  1m56.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m34.0s
+
+running (11m57.0s), 50/51 VUs, 638 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  78% ] 50/50 VUs  1m57.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m33.0s
+
+running (11m58.0s), 50/51 VUs, 639 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  79% ] 50/50 VUs  1m58.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m32.0s
+
+running (11m59.0s), 50/51 VUs, 642 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  79% ] 50/50 VUs  1m59.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m31.0s
+time="2026-03-12T13:30:14Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?size=1\": request timeout"
+
+running (12m00.0s), 50/51 VUs, 642 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  80% ] 50/50 VUs  2m00.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m30.0s
+
+running (12m01.0s), 50/51 VUs, 643 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  81% ] 50/50 VUs  2m01.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m29.0s
+
+running (12m02.0s), 50/51 VUs, 645 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  81% ] 50/50 VUs  2m02.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m28.0s
+time="2026-03-12T13:30:17Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?size=1\": request timeout"
+
+running (12m03.0s), 50/51 VUs, 647 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  82% ] 50/50 VUs  2m03.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m27.0s
+
+running (12m04.0s), 50/51 VUs, 649 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  83% ] 50/50 VUs  2m04.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m26.0s
+
+running (12m05.0s), 50/51 VUs, 651 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  83% ] 50/50 VUs  2m05.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m25.0s
+
+running (12m06.0s), 50/51 VUs, 652 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  84% ] 50/50 VUs  2m06.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m24.0s
+time="2026-03-12T13:30:21Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?size=1\": request timeout"
+
+running (12m07.0s), 50/51 VUs, 653 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  85% ] 50/50 VUs  2m07.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m23.0s
+
+running (12m08.0s), 50/51 VUs, 657 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  85% ] 50/50 VUs  2m08.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m22.0s
+
+running (12m09.0s), 50/51 VUs, 657 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  86% ] 50/50 VUs  2m09.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m21.0s
+time="2026-03-12T13:30:24Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?size=1\": request timeout"
+
+running (12m10.0s), 50/51 VUs, 659 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  87% ] 50/50 VUs  2m10.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m20.0s
+
+running (12m11.0s), 50/51 VUs, 661 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  87% ] 50/50 VUs  2m11.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m19.0s
+
+running (12m12.0s), 50/51 VUs, 662 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  88% ] 50/50 VUs  2m12.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m18.0s
+
+running (12m13.0s), 50/51 VUs, 662 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  89% ] 50/50 VUs  2m13.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m17.0s
+
+running (12m14.0s), 50/51 VUs, 665 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  89% ] 50/50 VUs  2m14.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m16.0s
+
+running (12m15.0s), 50/51 VUs, 666 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  90% ] 50/50 VUs  2m15.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m15.0s
+
+running (12m16.0s), 50/51 VUs, 667 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  91% ] 50/50 VUs  2m16.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m14.0s
+
+running (12m17.0s), 50/51 VUs, 668 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  91% ] 50/50 VUs  2m17.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m13.0s
+
+running (12m18.0s), 49/51 VUs, 670 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  92% ] 49/50 VUs  2m18.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m12.0s
+time="2026-03-12T13:30:34Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?size=1\": request timeout"
+
+running (12m19.0s), 49/51 VUs, 672 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  93% ] 49/50 VUs  2m19.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m11.0s
+
+running (12m20.0s), 49/51 VUs, 674 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  93% ] 49/50 VUs  2m20.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m10.0s
+
+running (12m21.0s), 49/51 VUs, 675 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  94% ] 49/50 VUs  2m21.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m09.0s
+time="2026-03-12T13:30:36Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?size=1\": request timeout"
+
+running (12m22.0s), 49/51 VUs, 675 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  95% ] 49/50 VUs  2m22.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m08.0s
+time="2026-03-12T13:30:37Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?size=1\": dial tcp 172.20.150.69:80: connect: connection refused"
+time="2026-03-12T13:30:38Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?size=1\": request timeout"
+
+running (12m23.0s), 49/51 VUs, 679 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  95% ] 49/50 VUs  2m23.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m07.0s
+
+running (12m24.0s), 49/51 VUs, 681 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  96% ] 49/50 VUs  2m24.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m06.0s
+
+running (12m25.0s), 49/51 VUs, 681 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  97% ] 49/50 VUs  2m25.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m05.0s
+time="2026-03-12T13:30:40Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?size=1\": request timeout"
+
+running (12m26.0s), 48/51 VUs, 683 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  97% ] 48/50 VUs  2m26.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m04.0s
+
+running (12m27.0s), 44/51 VUs, 687 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  98% ] 44/50 VUs  2m27.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m03.0s
+
+running (12m28.0s), 44/51 VUs, 687 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  99% ] 44/50 VUs  2m28.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m02.0s
+
+running (12m29.0s), 44/51 VUs, 688 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [  99% ] 44/50 VUs  2m29.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m01.0s
+time="2026-03-12T13:30:44Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?size=1\": request timeout"
+
+running (12m30.0s), 41/51 VUs, 691 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                   [ 100% ] 41/50 VUs  2m30.0s/2m30.0s
+get_categories            • [   0% ] waiting    00m00.0s
+
+running (12m31.0s), 41/51 VUs, 692 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ↓ [ 100% ] 41/50 VUs  2m30s
+get_categories              [   1% ] 01/50 VUs  0m01.0s/2m30.0s
+
+running (12m32.0s), 40/51 VUs, 693 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ↓ [ 100% ] 41/50 VUs  2m30s
+get_categories              [   1% ] 01/50 VUs  0m02.0s/2m30.0s
+
+running (12m33.0s), 38/51 VUs, 695 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ↓ [ 100% ] 41/50 VUs  2m30s
+get_categories              [   2% ] 01/50 VUs  0m03.0s/2m30.0s
+
+running (12m34.0s), 36/51 VUs, 697 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ↓ [ 100% ] 41/50 VUs  2m30s
+get_categories              [   3% ] 01/50 VUs  0m04.0s/2m30.0s
+
+running (12m35.0s), 34/51 VUs, 699 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ↓ [ 100% ] 41/50 VUs  2m30s
+get_categories              [   3% ] 01/50 VUs  0m05.0s/2m30.0s
+
+running (12m36.0s), 32/51 VUs, 701 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ↓ [ 100% ] 41/50 VUs  2m30s
+get_categories              [   4% ] 01/50 VUs  0m06.0s/2m30.0s
+
+running (12m37.0s), 31/51 VUs, 702 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ↓ [ 100% ] 41/50 VUs  2m30s
+get_categories              [   5% ] 01/50 VUs  0m07.0s/2m30.0s
+
+running (12m38.0s), 30/51 VUs, 703 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ↓ [ 100% ] 41/50 VUs  2m30s
+get_categories              [   5% ] 01/50 VUs  0m08.0s/2m30.0s
+
+running (12m39.0s), 26/51 VUs, 707 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ↓ [ 100% ] 41/50 VUs  2m30s
+get_categories              [   6% ] 01/50 VUs  0m09.0s/2m30.0s
+
+running (12m40.0s), 26/51 VUs, 707 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ↓ [ 100% ] 41/50 VUs  2m30s
+get_categories              [   7% ] 01/50 VUs  0m10.0s/2m30.0s
+
+running (12m41.0s), 24/51 VUs, 709 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ↓ [ 100% ] 41/50 VUs  2m30s
+get_categories              [   7% ] 01/50 VUs  0m11.0s/2m30.0s
+
+running (12m42.0s), 22/51 VUs, 711 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ↓ [ 100% ] 41/50 VUs  2m30s
+get_categories              [   8% ] 01/50 VUs  0m12.0s/2m30.0s
+
+running (12m43.0s), 21/51 VUs, 712 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ↓ [ 100% ] 41/50 VUs  2m30s
+get_categories              [   9% ] 01/50 VUs  0m13.0s/2m30.0s
+time="2026-03-12T13:30:58Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/search/products?size=1\": request timeout"
+
+running (12m44.0s), 21/51 VUs, 712 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ↓ [ 100% ] 41/50 VUs  2m30s
+get_categories              [   9% ] 01/50 VUs  0m14.0s/2m30.0s
+
+running (12m45.0s), 17/51 VUs, 716 complete and 7 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ↓ [ 100% ] 41/50 VUs  2m30s
+get_categories              [  10% ] 01/50 VUs  0m15.0s/2m30.0s
+
+running (12m46.0s), 15/51 VUs, 717 complete and 8 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ↓ [ 100% ] 41/50 VUs  2m30s
+get_categories              [  11% ] 01/50 VUs  0m16.0s/2m30.0s
+
+running (12m47.0s), 15/51 VUs, 717 complete and 8 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ↓ [ 100% ] 41/50 VUs  2m30s
+get_categories              [  11% ] 01/50 VUs  0m17.0s/2m30.0s
+
+running (12m48.0s), 14/51 VUs, 717 complete and 9 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ↓ [ 100% ] 41/50 VUs  2m30s
+get_categories              [  12% ] 01/50 VUs  0m18.0s/2m30.0s
+
+running (12m49.0s), 14/51 VUs, 718 complete and 9 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ↓ [ 100% ] 41/50 VUs  2m30s
+get_categories              [  13% ] 02/50 VUs  0m19.0s/2m30.0s
+
+running (12m50.0s), 12/51 VUs, 720 complete and 9 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ↓ [ 100% ] 41/50 VUs  2m30s
+get_categories              [  13% ] 02/50 VUs  0m20.0s/2m30.0s
+
+running (12m51.0s), 10/51 VUs, 722 complete and 9 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ↓ [ 100% ] 41/50 VUs  2m30s
+get_categories              [  14% ] 02/50 VUs  0m21.0s/2m30.0s
+
+running (12m52.0s), 10/51 VUs, 723 complete and 9 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ↓ [ 100% ] 41/50 VUs  2m30s
+get_categories              [  15% ] 03/50 VUs  0m22.0s/2m30.0s
+
+running (12m53.0s), 10/51 VUs, 723 complete and 9 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ↓ [ 100% ] 41/50 VUs  2m30s
+get_categories              [  15% ] 03/50 VUs  0m23.0s/2m30.0s
+
+running (12m54.0s), 07/51 VUs, 726 complete and 9 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ↓ [ 100% ] 41/50 VUs  2m30s
+get_categories              [  16% ] 03/50 VUs  0m24.0s/2m30.0s
+
+running (12m55.0s), 05/51 VUs, 727 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ↓ [ 100% ] 41/50 VUs  2m30s
+get_categories              [  17% ] 03/50 VUs  0m25.0s/2m30.0s
+
+running (12m56.0s), 06/51 VUs, 727 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ↓ [ 100% ] 41/50 VUs  2m30s
+get_categories              [  17% ] 04/50 VUs  0m26.0s/2m30.0s
+
+running (12m57.0s), 05/51 VUs, 728 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ↓ [ 100% ] 41/50 VUs  2m30s
+get_categories              [  18% ] 04/50 VUs  0m27.0s/2m30.0s
+
+running (12m58.0s), 05/51 VUs, 728 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ↓ [ 100% ] 41/50 VUs  2m30s
+get_categories              [  19% ] 04/50 VUs  0m28.0s/2m30.0s
+
+running (12m59.0s), 06/51 VUs, 728 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ↓ [ 100% ] 41/50 VUs  2m30s
+get_categories              [  19% ] 05/50 VUs  0m29.0s/2m30.0s
+
+running (13m00.0s), 05/51 VUs, 729 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  20% ] 05/50 VUs  0m30.0s/2m30.0s
+
+running (13m01.0s), 05/51 VUs, 730 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  21% ] 05/50 VUs  0m31.0s/2m30.0s
+
+running (13m02.0s), 06/51 VUs, 730 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  21% ] 06/50 VUs  0m32.0s/2m30.0s
+
+running (13m03.0s), 06/51 VUs, 730 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  22% ] 06/50 VUs  0m33.0s/2m30.0s
+
+running (13m04.0s), 06/51 VUs, 730 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  23% ] 06/50 VUs  0m34.0s/2m30.0s
+
+running (13m05.0s), 06/51 VUs, 730 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  23% ] 06/50 VUs  0m35.0s/2m30.0s
+
+running (13m06.0s), 07/51 VUs, 730 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  24% ] 07/50 VUs  0m36.0s/2m30.0s
+
+running (13m07.0s), 07/51 VUs, 730 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  25% ] 07/50 VUs  0m37.0s/2m30.0s
+
+running (13m08.0s), 07/51 VUs, 730 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  25% ] 07/50 VUs  0m38.0s/2m30.0s
+
+running (13m09.0s), 08/51 VUs, 730 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  26% ] 08/50 VUs  0m39.0s/2m30.0s
+
+running (13m10.0s), 08/51 VUs, 730 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  27% ] 08/50 VUs  0m40.0s/2m30.0s
+
+running (13m11.0s), 08/51 VUs, 730 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  27% ] 08/50 VUs  0m41.0s/2m30.0s
+
+running (13m12.0s), 09/51 VUs, 730 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  28% ] 09/50 VUs  0m42.0s/2m30.0s
+
+running (13m13.0s), 09/51 VUs, 730 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  29% ] 09/50 VUs  0m43.0s/2m30.0s
+
+running (13m14.0s), 09/51 VUs, 730 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  29% ] 09/50 VUs  0m44.0s/2m30.0s
+
+running (13m15.0s), 09/51 VUs, 730 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  30% ] 09/50 VUs  0m45.0s/2m30.0s
+
+running (13m16.0s), 10/51 VUs, 730 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  31% ] 10/50 VUs  0m46.0s/2m30.0s
+
+running (13m17.0s), 10/51 VUs, 730 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  31% ] 10/50 VUs  0m47.0s/2m30.0s
+
+running (13m18.0s), 10/51 VUs, 730 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  32% ] 10/50 VUs  0m48.0s/2m30.0s
+
+running (13m19.0s), 10/51 VUs, 731 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  33% ] 10/50 VUs  0m49.0s/2m30.0s
+
+running (13m20.0s), 10/51 VUs, 731 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  33% ] 10/50 VUs  0m50.0s/2m30.0s
+
+running (13m21.0s), 10/51 VUs, 731 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  34% ] 10/50 VUs  0m51.0s/2m30.0s
+
+running (13m22.0s), 10/51 VUs, 731 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  35% ] 10/50 VUs  0m52.0s/2m30.0s
+
+running (13m23.0s), 10/51 VUs, 732 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  35% ] 10/50 VUs  0m53.0s/2m30.0s
+
+running (13m24.0s), 10/51 VUs, 732 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  36% ] 10/50 VUs  0m54.0s/2m30.0s
+
+running (13m25.0s), 10/51 VUs, 732 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  37% ] 10/50 VUs  0m55.0s/2m30.0s
+
+running (13m26.0s), 10/51 VUs, 733 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  37% ] 10/50 VUs  0m56.0s/2m30.0s
+
+running (13m27.0s), 10/51 VUs, 733 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  38% ] 10/50 VUs  0m57.0s/2m30.0s
+
+running (13m28.0s), 10/51 VUs, 733 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  39% ] 10/50 VUs  0m58.0s/2m30.0s
+
+running (13m29.0s), 10/51 VUs, 734 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  39% ] 10/50 VUs  0m59.0s/2m30.0s
+
+running (13m30.0s), 10/51 VUs, 734 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  40% ] 10/50 VUs  1m00.0s/2m30.0s
+
+running (13m31.0s), 10/51 VUs, 734 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  41% ] 10/50 VUs  1m01.0s/2m30.0s
+
+running (13m32.0s), 10/51 VUs, 735 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  41% ] 10/50 VUs  1m02.0s/2m30.0s
+
+running (13m33.0s), 10/51 VUs, 736 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  42% ] 10/50 VUs  1m03.0s/2m30.0s
+
+running (13m34.0s), 10/51 VUs, 736 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  43% ] 10/50 VUs  1m04.0s/2m30.0s
+
+running (13m35.0s), 10/51 VUs, 736 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  43% ] 10/50 VUs  1m05.0s/2m30.0s
+
+running (13m36.0s), 10/51 VUs, 737 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  44% ] 10/50 VUs  1m06.0s/2m30.0s
+
+running (13m37.0s), 10/51 VUs, 737 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  45% ] 10/50 VUs  1m07.0s/2m30.0s
+
+running (13m38.0s), 10/51 VUs, 737 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  45% ] 10/50 VUs  1m08.0s/2m30.0s
+
+running (13m39.0s), 10/51 VUs, 738 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  46% ] 10/50 VUs  1m09.0s/2m30.0s
+
+running (13m40.0s), 10/51 VUs, 738 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  47% ] 10/50 VUs  1m10.0s/2m30.0s
+
+running (13m41.0s), 10/51 VUs, 738 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  47% ] 10/50 VUs  1m11.0s/2m30.0s
+
+running (13m42.0s), 10/51 VUs, 738 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  48% ] 10/50 VUs  1m12.0s/2m30.0s
+
+running (13m43.0s), 10/51 VUs, 739 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  49% ] 10/50 VUs  1m13.0s/2m30.0s
+
+running (13m44.0s), 10/51 VUs, 739 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  49% ] 10/50 VUs  1m14.0s/2m30.0s
+
+running (13m45.0s), 10/51 VUs, 739 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  50% ] 10/50 VUs  1m15.0s/2m30.0s
+
+running (13m46.0s), 11/51 VUs, 740 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  51% ] 11/50 VUs  1m16.0s/2m30.0s
+
+running (13m47.0s), 12/51 VUs, 740 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  51% ] 12/50 VUs  1m17.0s/2m30.0s
+
+running (13m48.0s), 13/51 VUs, 740 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  52% ] 13/50 VUs  1m18.0s/2m30.0s
+time="2026-03-12T13:32:03Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/categories\": dial tcp 172.20.150.69:80: connect: connection refused"
+time="2026-03-12T13:32:03Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/categories\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (13m49.0s), 15/51 VUs, 741 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  53% ] 15/50 VUs  1m19.0s/2m30.0s
+time="2026-03-12T13:32:04Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/categories\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (13m50.0s), 16/51 VUs, 743 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  53% ] 16/50 VUs  1m20.0s/2m30.0s
+time="2026-03-12T13:32:05Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/categories\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (13m51.0s), 17/51 VUs, 745 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  54% ] 17/50 VUs  1m21.0s/2m30.0s
+
+running (13m52.0s), 19/51 VUs, 745 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  55% ] 19/50 VUs  1m22.0s/2m30.0s
+time="2026-03-12T13:32:07Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/categories\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (13m53.0s), 20/51 VUs, 746 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  55% ] 20/50 VUs  1m23.0s/2m30.0s
+time="2026-03-12T13:32:08Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/categories\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (13m54.0s), 21/51 VUs, 748 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  56% ] 21/50 VUs  1m24.0s/2m30.0s
+time="2026-03-12T13:32:09Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/categories\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (13m55.0s), 23/51 VUs, 749 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  57% ] 23/50 VUs  1m25.0s/2m30.0s
+time="2026-03-12T13:32:10Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/categories\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (13m56.0s), 24/51 VUs, 749 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  57% ] 24/50 VUs  1m26.0s/2m30.0s
+
+running (13m57.0s), 25/51 VUs, 751 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  58% ] 25/50 VUs  1m27.0s/2m30.0s
+time="2026-03-12T13:32:12Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/categories\": dial tcp 172.20.150.69:80: connect: connection refused"
+time="2026-03-12T13:32:12Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/categories\": dial tcp 172.20.150.69:80: connect: connection refused"
+time="2026-03-12T13:32:13Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/categories\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (13m58.0s), 27/51 VUs, 752 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  59% ] 27/50 VUs  1m28.0s/2m30.0s
+time="2026-03-12T13:32:13Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/categories\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (13m59.0s), 28/51 VUs, 754 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  59% ] 28/50 VUs  1m29.0s/2m30.0s
+
+running (14m00.0s), 29/51 VUs, 756 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  60% ] 29/50 VUs  1m30.0s/2m30.0s
+time="2026-03-12T13:32:15Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/categories\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (14m01.0s), 31/51 VUs, 757 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  61% ] 31/50 VUs  1m31.0s/2m30.0s
+
+running (14m02.0s), 32/51 VUs, 758 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  61% ] 32/50 VUs  1m32.0s/2m30.0s
+
+running (14m03.0s), 33/51 VUs, 759 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  62% ] 33/50 VUs  1m33.0s/2m30.0s
+
+running (14m04.0s), 35/51 VUs, 759 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  63% ] 35/50 VUs  1m34.0s/2m30.0s
+time="2026-03-12T13:32:19Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/categories\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (14m05.0s), 36/51 VUs, 759 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  63% ] 36/50 VUs  1m35.0s/2m30.0s
+
+running (14m06.0s), 37/51 VUs, 760 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  64% ] 37/50 VUs  1m36.0s/2m30.0s
+time="2026-03-12T13:32:21Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/categories\": dial tcp 172.20.150.69:80: connect: connection refused"
+time="2026-03-12T13:32:22Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/categories\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (14m07.0s), 39/51 VUs, 762 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  65% ] 39/50 VUs  1m37.0s/2m30.0s
+time="2026-03-12T13:32:22Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/categories\": dial tcp 172.20.150.69:80: connect: connection refused"
+time="2026-03-12T13:32:23Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/categories\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (14m08.0s), 40/51 VUs, 764 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  65% ] 40/50 VUs  1m38.0s/2m30.0s
+time="2026-03-12T13:32:23Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/categories\": dial tcp 172.20.150.69:80: connect: connection refused"
+time="2026-03-12T13:32:24Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/categories\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (14m09.0s), 41/51 VUs, 766 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  66% ] 41/50 VUs  1m39.0s/2m30.0s
+
+running (14m10.0s), 43/51 VUs, 768 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  67% ] 43/50 VUs  1m40.0s/2m30.0s
+
+running (14m11.0s), 44/51 VUs, 768 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  67% ] 44/50 VUs  1m41.0s/2m30.0s
+time="2026-03-12T13:32:26Z" level=warning msg="Request Failed" error="Get \"http://productservice:80/categories\": dial tcp 172.20.150.69:80: connect: connection refused"
+
+running (14m12.0s), 45/51 VUs, 769 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  68% ] 45/50 VUs  1m42.0s/2m30.0s
+
+running (14m13.0s), 47/51 VUs, 770 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  69% ] 47/50 VUs  1m43.0s/2m30.0s
+
+running (14m14.0s), 48/51 VUs, 770 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  69% ] 48/50 VUs  1m44.0s/2m30.0s
+
+running (14m15.0s), 49/51 VUs, 770 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  70% ] 49/50 VUs  1m45.0s/2m30.0s
+
+running (14m16.0s), 50/51 VUs, 770 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  71% ] 50/50 VUs  1m46.0s/2m30.0s
+
+running (14m17.0s), 50/51 VUs, 772 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  71% ] 50/50 VUs  1m47.0s/2m30.0s
+
+running (14m18.0s), 50/51 VUs, 774 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  72% ] 50/50 VUs  1m48.0s/2m30.0s
+
+running (14m19.0s), 50/51 VUs, 774 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  73% ] 50/50 VUs  1m49.0s/2m30.0s
+
+running (14m20.0s), 50/51 VUs, 777 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  73% ] 50/50 VUs  1m50.0s/2m30.0s
+
+running (14m21.0s), 50/51 VUs, 778 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  74% ] 50/50 VUs  1m51.0s/2m30.0s
+
+running (14m22.0s), 50/51 VUs, 780 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  75% ] 50/50 VUs  1m52.0s/2m30.0s
+
+running (14m23.0s), 50/51 VUs, 781 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  75% ] 50/50 VUs  1m53.0s/2m30.0s
+
+running (14m24.0s), 50/51 VUs, 783 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  76% ] 50/50 VUs  1m54.0s/2m30.0s
+
+running (14m25.0s), 50/51 VUs, 784 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  77% ] 50/50 VUs  1m55.0s/2m30.0s
+
+running (14m26.0s), 50/51 VUs, 786 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  77% ] 50/50 VUs  1m56.0s/2m30.0s
+
+running (14m27.0s), 50/51 VUs, 789 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  78% ] 50/50 VUs  1m57.0s/2m30.0s
+
+running (14m28.0s), 50/51 VUs, 789 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  79% ] 50/50 VUs  1m58.0s/2m30.0s
+
+running (14m29.0s), 50/51 VUs, 791 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  79% ] 50/50 VUs  1m59.0s/2m30.0s
+
+running (14m30.0s), 50/51 VUs, 794 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  80% ] 50/50 VUs  2m00.0s/2m30.0s
+
+running (14m31.0s), 50/51 VUs, 794 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  81% ] 50/50 VUs  2m01.0s/2m30.0s
+
+running (14m32.0s), 50/51 VUs, 796 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  81% ] 50/50 VUs  2m02.0s/2m30.0s
+
+running (14m33.0s), 50/51 VUs, 799 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  82% ] 50/50 VUs  2m03.0s/2m30.0s
+
+running (14m34.0s), 50/51 VUs, 801 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  83% ] 50/50 VUs  2m04.0s/2m30.0s
+
+running (14m35.0s), 50/51 VUs, 802 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  83% ] 50/50 VUs  2m05.0s/2m30.0s
+
+running (14m36.0s), 50/51 VUs, 804 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  84% ] 50/50 VUs  2m06.0s/2m30.0s
+
+running (14m37.0s), 50/51 VUs, 805 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  85% ] 50/50 VUs  2m07.0s/2m30.0s
+
+running (14m38.0s), 50/51 VUs, 806 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  85% ] 50/50 VUs  2m08.0s/2m30.0s
+
+running (14m39.0s), 50/51 VUs, 808 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  86% ] 50/50 VUs  2m09.0s/2m30.0s
+
+running (14m40.0s), 50/51 VUs, 811 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  87% ] 50/50 VUs  2m10.0s/2m30.0s
+
+running (14m41.0s), 50/51 VUs, 812 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  87% ] 50/50 VUs  2m11.0s/2m30.0s
+
+running (14m42.0s), 50/51 VUs, 813 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  88% ] 50/50 VUs  2m12.0s/2m30.0s
+
+running (14m43.0s), 50/51 VUs, 815 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  89% ] 50/50 VUs  2m13.0s/2m30.0s
+
+running (14m44.0s), 50/51 VUs, 817 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  89% ] 50/50 VUs  2m14.0s/2m30.0s
+
+running (14m45.0s), 50/51 VUs, 819 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  90% ] 50/50 VUs  2m15.0s/2m30.0s
+
+running (14m46.0s), 49/51 VUs, 820 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  91% ] 49/50 VUs  2m16.0s/2m30.0s
+
+running (14m47.0s), 49/51 VUs, 822 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  91% ] 49/50 VUs  2m17.0s/2m30.0s
+
+running (14m48.0s), 49/51 VUs, 823 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  92% ] 49/50 VUs  2m18.0s/2m30.0s
+
+running (14m49.0s), 49/51 VUs, 824 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  93% ] 49/50 VUs  2m19.0s/2m30.0s
+
+running (14m50.0s), 49/51 VUs, 825 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  93% ] 49/50 VUs  2m20.0s/2m30.0s
+
+running (14m51.0s), 49/51 VUs, 827 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  94% ] 49/50 VUs  2m21.0s/2m30.0s
+
+running (14m52.0s), 49/51 VUs, 829 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  95% ] 49/50 VUs  2m22.0s/2m30.0s
+
+running (14m53.0s), 49/51 VUs, 831 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  95% ] 49/50 VUs  2m23.0s/2m30.0s
+
+running (14m54.0s), 49/51 VUs, 832 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  96% ] 49/50 VUs  2m24.0s/2m30.0s
+
+running (14m55.0s), 48/51 VUs, 834 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  97% ] 48/50 VUs  2m25.0s/2m30.0s
+
+running (14m56.0s), 46/51 VUs, 836 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  97% ] 46/50 VUs  2m26.0s/2m30.0s
+
+running (14m57.0s), 46/51 VUs, 836 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  98% ] 46/50 VUs  2m27.0s/2m30.0s
+
+running (14m58.0s), 44/51 VUs, 839 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  99% ] 44/50 VUs  2m28.0s/2m30.0s
+
+running (14m59.0s), 44/51 VUs, 839 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [  99% ] 44/50 VUs  2m29.0s/2m30.0s
+
+running (15m00.0s), 42/51 VUs, 841 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories              [ 100% ] 42/50 VUs  2m30.0s/2m30.0s
+
+running (15m01.0s), 39/51 VUs, 844 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories            ↓ [ 100% ] 42/50 VUs  2m30s
+
+running (15m02.0s), 37/51 VUs, 846 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories            ↓ [ 100% ] 42/50 VUs  2m30s
+
+running (15m03.0s), 35/51 VUs, 848 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories            ↓ [ 100% ] 42/50 VUs  2m30s
+
+running (15m04.0s), 33/51 VUs, 850 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories            ↓ [ 100% ] 42/50 VUs  2m30s
+
+running (15m05.0s), 31/51 VUs, 852 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories            ↓ [ 100% ] 42/50 VUs  2m30s
+
+running (15m06.0s), 31/51 VUs, 852 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories            ↓ [ 100% ] 42/50 VUs  2m30s
+
+running (15m07.0s), 29/51 VUs, 854 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories            ↓ [ 100% ] 42/50 VUs  2m30s
+
+running (15m08.0s), 27/51 VUs, 856 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories            ↓ [ 100% ] 42/50 VUs  2m30s
+
+running (15m09.0s), 26/51 VUs, 857 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories            ↓ [ 100% ] 42/50 VUs  2m30s
+
+running (15m10.0s), 25/51 VUs, 858 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories            ↓ [ 100% ] 42/50 VUs  2m30s
+
+running (15m11.0s), 21/51 VUs, 862 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories            ↓ [ 100% ] 42/50 VUs  2m30s
+
+running (15m12.0s), 20/51 VUs, 863 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories            ↓ [ 100% ] 42/50 VUs  2m30s
+
+running (15m13.0s), 19/51 VUs, 864 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories            ↓ [ 100% ] 42/50 VUs  2m30s
+
+running (15m14.0s), 16/51 VUs, 867 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories            ↓ [ 100% ] 42/50 VUs  2m30s
+
+running (15m15.0s), 15/51 VUs, 868 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories            ↓ [ 100% ] 42/50 VUs  2m30s
+
+running (15m16.0s), 14/51 VUs, 869 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories            ↓ [ 100% ] 42/50 VUs  2m30s
+
+running (15m17.0s), 14/51 VUs, 869 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories            ↓ [ 100% ] 42/50 VUs  2m30s
+
+running (15m18.0s), 12/51 VUs, 871 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories            ↓ [ 100% ] 42/50 VUs  2m30s
+
+running (15m19.0s), 10/51 VUs, 873 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories            ↓ [ 100% ] 42/50 VUs  2m30s
+
+running (15m20.0s), 10/51 VUs, 873 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories            ↓ [ 100% ] 42/50 VUs  2m30s
+
+running (15m21.0s), 07/51 VUs, 876 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories            ↓ [ 100% ] 42/50 VUs  2m30s
+
+running (15m22.0s), 06/51 VUs, 877 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories            ↓ [ 100% ] 42/50 VUs  2m30s
+
+running (15m23.0s), 04/51 VUs, 879 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories            ↓ [ 100% ] 42/50 VUs  2m30s
+
+running (15m24.0s), 03/51 VUs, 880 complete and 10 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories            ↓ [ 100% ] 42/50 VUs  2m30s
+
+running (15m25.0s), 01/51 VUs, 881 complete and 11 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories            ↓ [ 100% ] 42/50 VUs  2m30s
+
+running (15m26.0s), 01/51 VUs, 881 complete and 11 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories            ↓ [ 100% ] 42/50 VUs  2m30s
+
+running (15m27.0s), 01/51 VUs, 881 complete and 11 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories            ↓ [ 100% ] 42/50 VUs  2m30s
+
+
+  █ THRESHOLDS 
+
+    http_req_failed
+    ✗ 'rate<0.01' rate=100.00%
+
+
+  █ TOTAL RESULTS 
+
+    checks_total.......: 748     0.806438/s
+    checks_succeeded...: 0.00%   0 out of 748
+    checks_failed......: 100.00% 748 out of 748
+
+    ✗ full_text_search status 200
+      ↳  0% — ✓ 0 / ✗ 145
+    ✗ filtered_sorted_paginated status 200
+      ↳  0% — ✓ 0 / ✗ 168
+    ✗ multi_field_search status 200
+      ↳  0% — ✓ 0 / ✗ 137
+    ✗ autocomplete status 200
+      ↳  0% — ✓ 0 / ✗ 144
+    ✗ get_categories status 200
+      ↳  0% — ✓ 0 / ✗ 154
+
+    CUSTOM
+    autocomplete_duration................: min=0s       avg=27.92s med=30s   p(90)=30.01s p(95)=1m0s   p(99)=1m0s   max=1m0s  
+    errors...............................: 748     0.806438/s
+    filtered_sorted_paginated_duration...: min=0s       avg=23.75s med=30s   p(90)=30s    p(95)=30.01s p(99)=30.01s max=30.01s
+    full_text_search_duration............: min=0s       avg=27.52s med=30s   p(90)=59.99s p(95)=1m0s   p(99)=1m0s   max=1m0s  
+    get_categories_duration..............: min=0s       avg=25.91s med=30s   p(90)=30s    p(95)=30.01s p(99)=30.01s max=30.01s
+    multi_field_search_duration..........: min=0s       avg=28.47s med=30s   p(90)=30.01s p(95)=59.99s p(99)=1m0s   max=1m0s  
+
+    HTTP
+    http_req_duration....................: min=0s       avg=26.8s  med=30s   p(90)=30.01s p(95)=59.99s p(99)=1m0s   max=1m0s  
+    http_req_failed......................: 100.00% 890 out of 890
+    http_reqs............................: 890     0.959532/s
+
+    EXECUTION
+    iteration_duration...................: min=300.69ms avg=27.32s med=30.5s p(90)=31s    p(95)=1m0s   p(99)=1m1s   max=1m1s  
+    iterations...........................: 882     0.950907/s
+    vus..................................: 1       min=1          max=50
+    vus_max..............................: 51      min=51         max=51
+
+    NETWORK
+    data_received........................: 243 kB  262 B/s
+    data_sent............................: 93 kB   101 B/s
+
+
+
+
+running (15m27.5s), 00/51 VUs, 882 complete and 11 interrupted iterations
+full_text_search          ✓ [ 100% ] 00/50 VUs  2m30s
+filtered_sorted_paginated ✓ [ 100% ] 00/50 VUs  2m30s
+multi_field_search        ✓ [ 100% ] 00/50 VUs  2m30s
+autocomplete              ✓ [ 100% ] 00/50 VUs  2m30s
+get_by_id                 ✓ [ 100% ] 00/50 VUs  2m30s
+get_categories            ✓ [ 100% ] 00/50 VUs  2m30s
+time="2026-03-12T13:33:43Z" level=error msg="thresholds on metrics 'http_req_failed' have been crossed"


### PR DESCRIPTION
## Summary
- Add k6 benchmark result logs from MySQL baseline runs against 2M products on EKS
- 50 VU run: pod OOMKilled, 100% failure rate
- 15 VU light run: 100% failure, each LIKE query takes ~6 minutes

## Context
These results serve as the baseline for the upcoming Elasticsearch implementation, documenting that MySQL `LIKE '%query%'` is fundamentally unsuitable for full-text search at this data scale.

Closes #57

## Test plan
- [x] Verify log files are complete and readable