### PR TITLE
Fix N+1 category query in getSuggestions

### DIFF
--- a/src/main/java/com/vibevault/productservice/services/SearchServiceESImpl.java
+++ b/src/main/java/com/vibevault/productservice/services/SearchServiceESImpl.java
@@ -156,7 +156,7 @@ public class SearchServiceESImpl implements SearchService {
         }
 
         Map<UUID, Product> productMap = new HashMap<>();
-        productRepository.findAllById(productIds)
+        productRepository.findAllByIdWithCategory(productIds)
                 .forEach(p -> productMap.put(p.getId(), p));
 
         return productIds.stream()


### PR DESCRIPTION
## Summary
Replace `findAllById` with `findAllByIdWithCategory` in `getSuggestions()` to use JOIN FETCH and avoid per-product category queries.

## Problem
`getSuggestions()` was missed in the JOIN FETCH fix (PR #72). Each suggestion result triggered an individual `SELECT category` query — N+1 problem on the autocomplete endpoint.

## Test plan
- [ ] Merge after current reindex completes
- [ ] Deploy and run OpenSearch benchmark — verify autocomplete scenario has no N+1 in logs